### PR TITLE
Add From/FromError to Option/Either

### DIFF
--- a/either/either.go
+++ b/either/either.go
@@ -355,3 +355,11 @@ func RightOrElse[L any, R any](opt option.Option[R], f func() L) Either[L, R] {
 		},
 	)
 }
+
+// Returns Left[err] if err != nil. Returns Right[r] if err == nil.
+func From[R any](r R, err error) Either[error, R] {
+	if err != nil {
+		return Left[error, R]{Value: err}
+	}
+	return Right[error, R]{Value: r}
+}

--- a/either/either_test.go
+++ b/either/either_test.go
@@ -1,6 +1,7 @@
 package either_test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -708,6 +709,24 @@ func TestEither_RightOrElse(t *testing.T) {
 		})
 		expected := either.Left[string, int]{"hello"}
 		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestEither_From(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		res := either.From(3, nil)
+		expected := either.Right[error, int]{Value: 3}
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("not nil", func(t *testing.T) {
+		err := fmt.Errorf("error")
+		res := either.From(3, err)
+		expected := either.Left[error, int]{Value: err}
+		if res != expected {
 			t.Fail()
 		}
 	})

--- a/option/option.go
+++ b/option/option.go
@@ -280,3 +280,20 @@ func Match[T any, U any](opt Option[T], someArm func(Some[T]) U, nothingArm func
 		panic("option type is neither Some[T] nor Nothing[T]") // This should never happen.
 	}
 }
+
+// Returns an option from the provided value and boolean indicating if the value is valid.
+// Returns Nothing if ok is false.
+func From[T any](val T, ok bool) Option[T] {
+	if ok {
+		return Some[T]{Value: val}
+	}
+	return Nothing[T]{}
+}
+
+// Returns an option from the provided value and error.
+// Returns Some[T] if the error is nil.
+// Returns Nothing if the error is not nil.
+// NOTE: The error value is discarded. Use Either if this is not desired.
+func FromError[T any](val T, err error) Option[T] {
+	return From(val, err == nil)
+}

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -1,6 +1,7 @@
 package option_test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -468,6 +469,40 @@ func TestOption_Match(t *testing.T) {
 		)
 		expected := "nothing"
 		if res != expected || someArmCalls != 0 || nothingArmCalls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestOption_From(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		res := option.From(3, true)
+		expected := option.Some[int]{Value: 3}
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("not ok", func(t *testing.T) {
+		res := option.From(3, false)
+		expected := option.Nothing[int]{}
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestOption_FromError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		res := option.FromError(3, nil)
+		expected := option.Some[int]{Value: 3}
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("not nil", func(t *testing.T) {
+		res := option.FromError(3, fmt.Errorf("error"))
+		expected := option.Nothing[int]{}
+		if res != expected {
 			t.Fail()
 		}
 	})


### PR DESCRIPTION
Add convenience functions to wrap the standard Go pattern of functions that return a value and err to indicate if it was successful or not.

Closes #37 