### PR TITLE
Rename Either Left/Right to First/Second

### DIFF
--- a/either/either.go
+++ b/either/either.go
@@ -6,360 +6,361 @@ import (
 	"github.com/sidkurella/goption/option"
 )
 
-// Implements Monad[Either[L, T1], Either[L, T2], T1].
-type EitherMonad[L any, T1 any, T2 any] struct {
+// Implements Monad[Either[T1, E], Either[T2, E], T1].
+type EitherMonad[T1 any, E any, T2 any] struct {
 }
 
-func (m EitherMonad[L, T1, T2]) Bind(val Either[L, T1], f func(T1) Either[L, T2]) Either[L, T2] {
+func (m EitherMonad[T1, E, T2]) Bind(val Either[T1, E], f func(T1) Either[T2, E]) Either[T2, E] {
 	return Match(val,
-		func(l Left[L, T1]) Either[L, T2] {
-			return Left[L, T2]{Value: l.Value}
+		func(o First[T1, E]) Either[T2, E] {
+			return f(o.Value)
 		},
-		func(r Right[L, T1]) Either[L, T2] {
-			return f(r.Value)
+		func(e Second[T1, E]) Either[T2, E] {
+			return Second[T2, E]{Value: e.Value}
 		},
 	)
 }
 
-func (m EitherMonad[L, T1, T2]) Return(val T1) Either[L, T1] {
-	return Right[L, T1]{Value: val}
+func (m EitherMonad[T1, E, T2]) Return(val T1) Either[T1, E] {
+	return First[T1, E]{Value: val}
 }
 
-// Either type. Represents one of two values (Left or Right).
-// In the common case of success or failure, success is right (Right is Right) and failure is Left.
-type Either[L any, R any] interface {
+// Either type. Represents one of two possible values.
+// In the common success/failure case, represents either success (First) or failure (Second).
+type Either[T any, E any] interface {
 	// Sentinel method to prevent creation of other either types.
 	isEither()
 
-	// Returns true if the either is Right.
-	IsRight() bool
-	// Returns true if the either is Right and matches the given predicate.
-	IsRightAnd(pred func(*R) bool) bool
-	// Returns true if the either is Left.
-	IsLeft() bool
-	// Returns true if the either is Left and matches the given predicate.
-	IsLeftAnd(pred func(*L) bool) bool
+	// Returns true if the either is First.
+	IsFirst() bool
+	// Returns true if the either is First and matches the given predicate.
+	IsFirstAnd(pred func(*T) bool) bool
+	// Returns true if the either is Second.
+	IsSecond() bool
+	// Returns true if the either is Second and matches the given predicate.
+	IsSecondAnd(pred func(*E) bool) bool
 
-	// Converts from Either[L, R] to Option[R].
-	// Converts self into an Option[R], discarding the left value, if any.
-	Right() option.Option[R]
-	// Converts from Either[L, R] to Option[L].
-	// Converts self into an Option[L], and discarding the right value, if any.
-	Left() option.Option[L]
+	// Converts from Either[T, E] to Option[T].
+	// Converts self into an Option[T], discarding the second value, if any.
+	First() option.Option[T]
+	// Converts from Either[T, E] to Option[E].
+	// Converts self into an Option[E], and discarding the first value, if any.
+	Second() option.Option[E]
 
-	// Unwrap returns the contained Right value. Panics if it is Left.
-	Unwrap() R
-	// Returns the contained Right value. If the either is Left, returns the provided default.
+	// Unwrap returns the contained First value. Panics if it is Second.
+	Unwrap() T
+	// Returns the contained First value. If the either is Second, returns the provided default.
 	// Default value is eagerly evaluated. Consider using UnwrapOrElse if providing the either of a function call.
-	UnwrapOr(defaultValue R) R
-	// Returns the contained Right value. If the either is Left, computes the default from the provided closure.
-	UnwrapOrElse(defaultFunc func(L) R) R
-	// Returns the contained Left value. Panics if it is Right.
-	UnwrapLeft() L
-	// Returns the contained Left value. If the either is Right, returns the provided default.
-	UnwrapLeftOr(defaultValue L) L
-	// Returns the contained Left value. If the either is Right, computes the default from the provided closure.
-	UnwrapLeftOrElse(defaultFunc func(R) L) L
+	UnwrapOr(defaultValue T) T
+	// Returns the contained First value. If the either is Second, computes the default from the provided closure.
+	UnwrapOrElse(defaultFunc func(E) T) T
+	// Returns the contained Second value. Panics if it is First.
+	UnwrapSecond() E
+	// Returns the contained Second value. If the either is First, returns the provided default.
+	UnwrapSecondOr(defaultValue E) E
+	// Returns the contained Second value. If the either is First, computes the default from the provided closure.
+	UnwrapSecondOrElse(defaultFunc func(T) E) E
 
-	// Returns the contained Right value. Panics with the given message if the either is not Right.
-	Expect(msg string) R
-	// Returns the contained Left value. Panics with the given message if the either is not Left.
-	ExpectLeft(msg string) L
+	// Returns the contained First value. Panics with the given message if the either is not First.
+	Expect(msg string) T
+	// Returns the contained Second value. Panics with the given message if the either is not Second.
+	ExpectSecond(msg string) E
 
 	String() string
 }
 
 //=====================================================
 
-type Right[L any, R any] struct {
-	Value R
+type First[T any, E any] struct {
+	Value T
 }
 
-func (r Right[L, R]) isEither() {
+func (o First[T, E]) isEither() {
 }
 
-func (r Right[L, R]) IsRight() bool {
+func (o First[T, E]) IsFirst() bool {
 	return true
 }
 
-func (r Right[L, R]) IsLeft() bool {
+func (o First[T, E]) IsSecond() bool {
 	return false
 }
 
-func (r Right[L, R]) Right() option.Option[R] {
-	return option.Some[R]{Value: r.Value}
+func (o First[T, E]) First() option.Option[T] {
+	return option.Some[T]{Value: o.Value}
 }
 
-func (r Right[L, R]) IsRightAnd(pred func(*R) bool) bool {
-	return pred(&r.Value)
+func (o First[T, E]) IsFirstAnd(pred func(*T) bool) bool {
+	return pred(&o.Value)
 }
 
-func (r Right[L, R]) Left() option.Option[L] {
-	return option.Nothing[L]{}
+func (o First[T, E]) Second() option.Option[E] {
+	return option.Nothing[E]{}
 }
 
-func (r Right[L, R]) IsLeftAnd(pred func(*L) bool) bool {
+func (o First[T, E]) IsSecondAnd(pred func(*E) bool) bool {
 	return false
 }
 
-func (r Right[L, R]) Expect(_ string) R {
-	return r.Value
+func (o First[T, E]) Expect(_ string) T {
+	return o.Value
 }
 
-func (r Right[L, R]) ExpectLeft(msg string) L {
+func (o First[T, E]) ExpectSecond(msg string) E {
 	panic(msg)
 }
 
-func (r Right[L, R]) Unwrap() R {
-	return r.Value
+func (o First[T, E]) Unwrap() T {
+	return o.Value
 }
 
-func (r Right[L, R]) UnwrapOr(_ R) R {
-	return r.Value
+func (o First[T, E]) UnwrapOr(_ T) T {
+	return o.Value
 }
 
-func (r Right[L, R]) UnwrapOrElse(_ func(L) R) R {
-	return r.Value
+func (o First[T, E]) UnwrapOrElse(_ func(E) T) T {
+	return o.Value
 }
 
-func (r Right[L, R]) UnwrapLeft() L {
-	panic(r.Value)
+func (o First[T, E]) UnwrapSecond() E {
+	panic(o.Value)
 }
 
-func (r Right[L, R]) UnwrapLeftOr(defaultValue L) L {
+func (o First[T, E]) UnwrapSecondOr(defaultValue E) E {
 	return defaultValue
 }
 
-func (r Right[L, R]) UnwrapLeftOrElse(defaultFunc func(R) L) L {
-	return defaultFunc(r.Value)
+func (o First[T, E]) UnwrapSecondOrElse(defaultFunc func(T) E) E {
+	return defaultFunc(o.Value)
 }
 
-func (r Right[L, R]) String() string {
-	return fmt.Sprintf("Right(%v)", r.Value)
+func (o First[T, E]) String() string {
+	return fmt.Sprintf("First(%v)", o.Value)
 }
 
 //=====================================================
 
-type Left[L any, R any] struct {
-	Value L
+type Second[T any, E any] struct {
+	Value E
 }
 
-func (l Left[L, R]) isEither() {
+func (e Second[T, E]) isEither() {
 }
 
-func (l Left[L, R]) IsRight() bool {
+func (e Second[T, E]) IsFirst() bool {
 	return false
 }
 
-func (l Left[L, R]) IsRightAnd(pred func(*R) bool) bool {
+func (e Second[T, E]) IsFirstAnd(pred func(*T) bool) bool {
 	return false
 }
 
-func (l Left[L, R]) IsLeft() bool {
+func (e Second[T, E]) IsSecond() bool {
 	return true
 }
 
-func (l Left[L, R]) IsLeftAnd(pred func(*L) bool) bool {
-	return pred(&l.Value)
+func (e Second[T, E]) IsSecondAnd(pred func(*E) bool) bool {
+	return pred(&e.Value)
 }
 
-func (l Left[L, R]) Right() option.Option[R] {
-	return option.Nothing[R]{}
+func (e Second[T, E]) First() option.Option[T] {
+	return option.Nothing[T]{}
 }
 
-func (l Left[L, R]) Left() option.Option[L] {
-	return option.Some[L]{Value: l.Value}
+func (e Second[T, E]) Second() option.Option[E] {
+	return option.Some[E]{Value: e.Value}
 }
 
-func (l Left[L, R]) Expect(msg string) R {
+func (e Second[T, E]) Expect(msg string) T {
 	panic(msg)
 }
 
-func (l Left[L, R]) ExpectLeft(_ string) L {
-	return l.Value
+func (e Second[T, E]) ExpectSecond(_ string) E {
+	return e.Value
 }
 
-func (l Left[L, R]) Unwrap() R {
-	panic(l.Value)
+func (e Second[T, E]) Unwrap() T {
+	panic(e.Value)
 }
 
-func (l Left[L, R]) UnwrapOr(defaultValue R) R {
+func (e Second[T, E]) UnwrapOr(defaultValue T) T {
 	return defaultValue
 }
 
-func (l Left[L, R]) UnwrapOrElse(f func(L) R) R {
-	return f(l.Value)
+func (e Second[T, E]) UnwrapOrElse(f func(E) T) T {
+	return f(e.Value)
 }
 
-func (l Left[L, R]) UnwrapLeft() L {
-	return l.Value
+func (e Second[T, E]) UnwrapSecond() E {
+	return e.Value
 }
 
-func (l Left[L, R]) UnwrapLeftOr(_ L) L {
-	return l.Value
+func (e Second[T, E]) UnwrapSecondOr(_ E) E {
+	return e.Value
 }
 
-func (l Left[L, R]) UnwrapLeftOrElse(_ func(R) L) L {
-	return l.Value
+func (e Second[T, E]) UnwrapSecondOrElse(_ func(T) E) E {
+	return e.Value
 }
 
-func (l Left[L, R]) String() string {
-	return fmt.Sprintf("Left(%v)", l.Value)
+func (e Second[T, E]) String() string {
+	return fmt.Sprintf("Second(%v)", e.Value)
 }
 
 //=====================================================
 
-// Returns e2 if e1 is Right, otherwise returns the Left value of e1.
-func And[L any, R any, R2 any](e1 Either[L, R], e2 Either[L, R2]) Either[L, R2] {
-	return EitherMonad[L, R, R2]{}.Bind(
-		e1,
-		func(_ R) Either[L, R2] {
-			return e2
+// Returns res2 if res1 is First, otherwise returns the Second value of res1.
+func And[T any, E any, U any](res1 Either[T, E], res2 Either[U, E]) Either[U, E] {
+	return EitherMonad[T, E, U]{}.Bind(
+		res1,
+		func(_ T) Either[U, E] {
+			return res2
 		},
 	)
 }
 
-// Returns f(R) if e1 is Right[R], otherwise returns the Left value of e1.
-func AndThen[L any, R any, R2 any](e1 Either[L, R], f func(R) Either[L, R2]) Either[L, R2] {
-	return EitherMonad[L, R, R2]{}.Bind(e1, f)
+// Returns f(T) if res1 is First[T], otherwise returns the Second value of res1.
+func AndThen[T any, E any, U any](res1 Either[T, E], f func(T) Either[U, E]) Either[U, E] {
+	return EitherMonad[T, E, U]{}.Bind(res1, f)
 }
 
-// Flattens a either of type Either[L, Either[L, R]] to just Either[L, R].
-func Flatten[L any, R any](e Either[L, Either[L, R]]) Either[L, R] {
-	return Match(e,
-		func(l Left[L, Either[L, R]]) Either[L, R] {
-			return Left[L, R]{Value: l.Value}
+// Flattens a either of type Either[Either[T, E], E] to just Either[T, E].
+func Flatten[T any, E any](res Either[Either[T, E], E]) Either[T, E] {
+	return Match(res,
+		func(o First[Either[T, E], E]) Either[T, E] {
+			return o.Value
 		},
-		func(r Right[L, Either[L, R]]) Either[L, R] {
-			return r.Value
+		func(e Second[Either[T, E], E]) Either[T, E] {
+			return Second[T, E]{Value: e.Value}
 		},
 	)
 }
 
-// Maps a Either[L, R] to Either[L, R2] by applying a function to a contained Right value.
-// Leaves an Left value untouched.
-func Map[L any, R any, R2 any](e Either[L, R], f func(R) R2) Either[L, R2] {
-	return Match(e,
-		func(l Left[L, R]) Either[L, R2] {
-			return Left[L, R2]{Value: l.Value}
+// Maps a Either[T, E] to Either[U, E] by applying a function to a contained First value.
+// Leaves an Second value untouched.
+func Map[T any, E any, U any](res Either[T, E], f func(T) U) Either[U, E] {
+	return Match(res,
+		func(o First[T, E]) Either[U, E] {
+			return First[U, E]{Value: f(o.Value)}
 		},
-		func(r Right[L, R]) Either[L, R2] {
-			return Right[L, R2]{Value: f(r.Value)}
-		},
-	)
-}
-
-// Maps a Either[L, R] to Either[L2, R] by applying a function to a contained Left value.
-// Leaves an Right value untouched.
-func MapLeft[L any, L2 any, R any](e Either[L, R], f func(L) L2) Either[L2, R] {
-	return Match(e,
-		func(l Left[L, R]) Either[L2, R] {
-			return Left[L2, R]{Value: f(l.Value)}
-		},
-		func(r Right[L, R]) Either[L2, R] {
-			return Right[L2, R]{Value: r.Value}
+		func(e Second[T, E]) Either[U, E] {
+			return Second[U, E]{Value: e.Value}
 		},
 	)
 }
 
-// Maps a Either[L, R] to Either[L, R2] by applying a function to a contained Right value.
-// Returns the provided default if it is Left.
+// Maps a Either[T, E] to Either[T, F] by applying a function to a contained Second value.
+// Leaves an First value untouched.
+func MapSecond[T any, E any, F any](res Either[T, E], f func(E) F) Either[T, F] {
+	return Match(res,
+		func(o First[T, E]) Either[T, F] {
+			return First[T, F]{Value: o.Value}
+		},
+		func(e Second[T, E]) Either[T, F] {
+			return Second[T, F]{Value: f(e.Value)}
+		},
+	)
+}
+
+// Maps a Either[T, E] to Either[U, E] by applying a function to a contained First value.
+// Returns the provided default if it is Second.
 // Default value is eagerly evaluated. Consider using MapOrElse if you are passing the either of a function call.
-func MapOr[L any, R any, R2 any](e Either[L, R], defaultValue R2, f func(R) R2) Either[L, R2] {
-	return Match(e,
-		func(l Left[L, R]) Either[L, R2] {
-			return Right[L, R2]{Value: defaultValue}
+func MapOr[T any, E any, U any](res Either[T, E], defaultValue U, f func(T) U) Either[U, E] {
+	return Match(res,
+		func(o First[T, E]) Either[U, E] {
+			return First[U, E]{Value: f(o.Value)}
 		},
-		func(r Right[L, R]) Either[L, R2] {
-			return Right[L, R2]{Value: f(r.Value)}
+		func(e Second[T, E]) Either[U, E] {
+			return First[U, E]{Value: defaultValue}
 		},
 	)
 }
 
-// Maps a Either[L, R] to Either[L, R2] by applying a function to a contained Right value.
-// Returns the either produced by the default function if it is Left.
+// Maps a Either[T, E] to Either[U, E] by applying a function to a contained First value.
+// Returns the either produced by the default function if it is Second.
 // Default is lazily evaluated.
-func MapOrElse[L any, R any, R2 any](e Either[L, R], defaultFunc func(L) R2, f func(R) R2) Either[L, R2] {
-	return Match(e,
-		func(l Left[L, R]) Either[L, R2] {
-			return Right[L, R2]{Value: defaultFunc(l.Value)}
+func MapOrElse[T any, E any, U any](res Either[T, E], defaultFunc func(E) U, f func(T) U) Either[U, E] {
+	return Match(res,
+		func(o First[T, E]) Either[U, E] {
+			return First[U, E]{Value: f(o.Value)}
 		},
-		func(r Right[L, R]) Either[L, R2] {
-			return Right[L, R2]{Value: f(r.Value)}
-		},
-	)
-}
-
-// Returns e2 if the either is Left, otherwise returns the Right value of e1.
-// e2 is eagerly evaluated. Consider using OrElse if you are passing the either of a function call.
-func Or[L any, L2 any, R any](e1 Either[L, R], e2 Either[L2, R]) Either[L2, R] {
-	return Match(e1,
-		func(l Left[L, R]) Either[L2, R] {
-			return e2
-		},
-		func(r Right[L, R]) Either[L2, R] {
-			return Right[L2, R]{Value: r.Value}
+		func(e Second[T, E]) Either[U, E] {
+			return First[U, E]{Value: defaultFunc(e.Value)}
 		},
 	)
 }
 
-// Returns f(L) if the either is Left[L], otherwise returns the Right value of e.
+// Returns res2 if the either is Second, otherwise returns the First value of res1.
+// res2 is eagerly evaluated. Consider using OrElse if you are passing the either of a function call.
+func Or[T any, E any, F any](res1 Either[T, E], res2 Either[T, F]) Either[T, F] {
+	return Match(res1,
+		func(o First[T, E]) Either[T, F] {
+			return First[T, F]{Value: o.Value}
+		},
+		func(_ Second[T, E]) Either[T, F] {
+			return res2
+		},
+	)
+}
+
+// Returns f(E) if the either is Second[E], otherwise returns the First value of res1.
 // f is lazily evaluated.
-func OrElse[L any, L2 any, R any](e Either[L, R], f func(L) Either[L2, R]) Either[L2, R] {
-	return Match(e,
-		func(l Left[L, R]) Either[L2, R] {
-			return f(l.Value)
+func OrElse[T any, E any, F any](res1 Either[T, E], f func(E) Either[T, F]) Either[T, F] {
+	return Match(res1,
+		func(o First[T, E]) Either[T, F] {
+			return First[T, F]{Value: o.Value}
 		},
-		func(r Right[L, R]) Either[L2, R] {
-			return Right[L2, R]{Value: r.Value}
+		func(e Second[T, E]) Either[T, F] {
+			return f(e.Value)
 		},
 	)
 }
 
-// Match calls leftArm if the either is Left[L] and returns that.
-// It calls rightArm if the either is Right[R] and returns that instead.
+// Match calls firstArm if the either is First[T] and returns that either.
+// It calls secondArm if the either is Second[E] and returns that instead.
 // The two functions must return the same type.
-func Match[L any, R any, U any](e Either[L, R], leftArm func(Left[L, R]) U, rightArm func(Right[L, R]) U) U {
-	switch inner := e.(type) {
-	case Left[L, R]:
-		return leftArm(inner)
-	case Right[L, R]:
-		return rightArm(inner)
+func Match[T any, E any, U any](res Either[T, E], firstArm func(First[T, E]) U, secondArm func(Second[T, E]) U) U {
+	switch inner := res.(type) {
+	case First[T, E]:
+		return firstArm(inner)
+	case Second[T, E]:
+		return secondArm(inner)
 	default:
-		panic("either type is neither Left[L, R] nor Right[L, R]") // This should never happen.
+		panic("either type is neither First[T, E] nor Second[T, E]") // This should never happen.
 	}
 }
 
-// Converts an Option[R] to a Either[L, R], mapping Some[R] to Right[R], and Nothing to Left[err].
-// Arguments are eagerly evaluated; consider using RightOrElse if passing the either of a function call.
-func RightOr[L any, R any](opt option.Option[R], err L) Either[L, R] {
+// Converts an Option[T] to a Either[T, E], mapping Some[T] to First[T], and Nothing to Second[second].
+// Arguments are eagerly evaluated; consider using FirstOrElse if passing the either of a function call.
+func FirstOr[T any, E any](opt option.Option[T], second E) Either[T, E] {
 	return option.Match(opt,
-		func(s option.Some[R]) Either[L, R] {
-			return Right[L, R]{Value: s.Value}
+		func(s option.Some[T]) Either[T, E] {
+			return First[T, E]{Value: s.Value}
 		},
-		func(_ option.Nothing[R]) Either[L, R] {
-			return Left[L, R]{Value: err}
+		func(n option.Nothing[T]) Either[T, E] {
+			return Second[T, E]{Value: second}
 		},
 	)
 }
 
-// Converts an Option[R] to a Either[L, R], mapping Some[R] to Right[R], and Nothing to Left[f()].
+// Converts an Option[T] to a Either[T, E], mapping Some[T] to First[T], and Nothing to Second[f()].
 // f is lazily evaluated.
-func RightOrElse[L any, R any](opt option.Option[R], f func() L) Either[L, R] {
+func FirstOrElse[T any, E any](opt option.Option[T], f func() E) Either[T, E] {
 	return option.Match(opt,
-		func(s option.Some[R]) Either[L, R] {
-			return Right[L, R]{Value: s.Value}
+		func(s option.Some[T]) Either[T, E] {
+			return First[T, E]{Value: s.Value}
 		},
-		func(n option.Nothing[R]) Either[L, R] {
-			return Left[L, R]{Value: f()}
+		func(n option.Nothing[T]) Either[T, E] {
+			return Second[T, E]{Value: f()}
 		},
 	)
 }
 
-// Returns Left[err] if err != nil. Returns Right[r] if err == nil.
-func From[R any](r R, err error) Either[error, R] {
+// Returns First[r] if err == nil.
+// Returns Second[err] if err != nil.
+func From[T any](value T, err error) Either[T, error] {
 	if err != nil {
-		return Left[error, R]{Value: err}
+		return Second[T, error]{Value: err}
 	}
-	return Right[error, R]{Value: r}
+	return First[T, error]{Value: value}
 }

--- a/either/either_test.go
+++ b/either/either_test.go
@@ -9,142 +9,142 @@ import (
 	"github.com/sidkurella/goption/option"
 )
 
-func TestEither_IsRight(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		if !val.IsRight() {
+func TestEither_IsFirst(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
+		if !val.IsFirst() {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"err val"}
-		if val.IsRight() {
-			t.Fail()
-		}
-	})
-}
-
-func TestEither_IsLeft(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		if val.IsLeft() {
-			t.Fail()
-		}
-	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"err val"}
-		if !val.IsLeft() {
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"second val"}
+		if val.IsFirst() {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_IsRightAnd(t *testing.T) {
-	t.Run("Right, passes predicate", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		if !val.IsRightAnd(func(t *int) bool { return (*t) == 3 }) {
+func TestEither_IsSecond(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
+		if val.IsSecond() {
 			t.Fail()
 		}
 	})
-	t.Run("Right, fails predicate", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		if val.IsRightAnd(func(t *int) bool { return (*t) == 4 }) {
-			t.Fail()
-		}
-	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"err val"}
-		if val.IsRightAnd(func(t *int) bool { return (*t) == 4 }) {
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"second val"}
+		if !val.IsSecond() {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_IsLeftAnd(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		if val.IsLeftAnd(func(t *string) bool { return (*t) == "hello" }) {
+func TestEither_IsFirstAnd(t *testing.T) {
+	t.Run("First, passes predicate", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
+		if !val.IsFirstAnd(func(t *int) bool { return (*t) == 3 }) {
 			t.Fail()
 		}
 	})
-	t.Run("Left, passes predicate", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
-		if !val.IsLeftAnd(func(t *string) bool { return (*t) == "hello" }) {
+	t.Run("First, fails predicate", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
+		if val.IsFirstAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
 	})
-	t.Run("Left, fails predicate", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"world"}
-		if val.IsLeftAnd(func(t *string) bool { return (*t) == "hello" }) {
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"second val"}
+		if val.IsFirstAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_Right(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+func TestEither_IsSecondAnd(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
+		if val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+	t.Run("Second, passes predicate", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
+		if !val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+	t.Run("Second, fails predicate", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"world"}
+		if val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+}
+
+func TestEither_First(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := option.Some[int]{Value: 3}
-		if val.Right() != expected {
+		if val.First() != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := option.Nothing[int]{}
-		if val.Right() != expected {
+		if val.First() != expected {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_Left(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+func TestEither_Second(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := option.Nothing[string]{}
-		if val.Left() != expected {
+		if val.Second() != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := option.Some[string]{Value: "hello"}
-		if val.Left() != expected {
+		if val.Second() != expected {
 			t.Fail()
 		}
 	})
 }
 
 func TestEither_Unwrap(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := 3
 		if val.Unwrap() != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("Panic was expected but did not occur")
 			}
 		}()
 
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		_ = val.Unwrap()
 	})
 }
 
 func TestEither_UnwrapOr(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := 3
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := 4
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
@@ -153,9 +153,9 @@ func TestEither_UnwrapOr(t *testing.T) {
 }
 
 func TestEither_UnwrapOrElse(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
-		var val either.Either[string, int] = either.Right[string, int]{3}
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := 3
 		if val.UnwrapOrElse(func(_ string) int {
 			calls++
@@ -164,9 +164,9 @@ func TestEither_UnwrapOrElse(t *testing.T) {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := 5
 		if val.UnwrapOrElse(func(s string) int {
 			calls++
@@ -177,60 +177,60 @@ func TestEither_UnwrapOrElse(t *testing.T) {
 	})
 }
 
-func TestEither_UnwrapLeft(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+func TestEither_UnwrapSecond(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("Panic was expected but did not occur")
 			}
 		}()
 
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		_ = val.UnwrapLeft()
+		var val either.Either[int, string] = either.First[int, string]{3}
+		_ = val.UnwrapSecond()
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := "hello"
-		if val.UnwrapLeft() != expected {
+		if val.UnwrapSecond() != expected {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_UnwrapLeftOr(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+func TestEither_UnwrapSecondOr(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := "world"
-		if val.UnwrapLeftOr("world") != expected {
+		if val.UnwrapSecondOr("world") != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := "hello"
-		if val.UnwrapLeftOr("world") != expected {
+		if val.UnwrapSecondOr("world") != expected {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_UnwrapLeftOrElse(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+func TestEither_UnwrapSecondOrElse(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
-		var val either.Either[string, int] = either.Right[string, int]{3}
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := "3"
-		if val.UnwrapLeftOrElse(func(i int) string {
+		if val.UnwrapSecondOrElse(func(i int) string {
 			calls++
 			return strconv.Itoa(i)
 		}) != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := "hello"
-		if val.UnwrapLeftOrElse(func(i int) string {
+		if val.UnwrapSecondOrElse(func(i int) string {
 			calls++
 			return strconv.Itoa(i)
 		}) != expected || calls != 0 {
@@ -240,14 +240,14 @@ func TestEither_UnwrapLeftOrElse(t *testing.T) {
 }
 
 func TestEither_Expect(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		var val either.Either[string, int] = either.Right[string, int]{3}
+	t.Run("First", func(t *testing.T) {
+		var val either.Either[int, string] = either.First[int, string]{3}
 		expected := 3
 		if val.Expect("don't panic") != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		msg := "panic expected"
 		defer func() {
 			r := recover()
@@ -258,13 +258,13 @@ func TestEither_Expect(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		_ = val.Expect(msg)
 	})
 }
 
-func TestEither_ExpectLeft(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+func TestEither_ExpectSecond(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		msg := "panic expected"
 		defer func() {
 			r := recover()
@@ -275,55 +275,55 @@ func TestEither_ExpectLeft(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[string, int] = either.Right[string, int]{3}
-		_ = val.ExpectLeft(msg)
+		var val either.Either[int, string] = either.First[int, string]{3}
+		_ = val.ExpectSecond(msg)
 	})
-	t.Run("Left", func(t *testing.T) {
-		var val either.Either[string, int] = either.Left[string, int]{"hello"}
+	t.Run("Second", func(t *testing.T) {
+		var val either.Either[int, string] = either.Second[int, string]{"hello"}
 		expected := "hello"
-		if val.ExpectLeft("don't panic") != expected {
+		if val.ExpectSecond("don't panic") != expected {
 			t.Fail()
 		}
 	})
 }
 
 func TestEither_And(t *testing.T) {
-	t.Run("Right, Right", func(t *testing.T) {
-		res := either.And[string, int, float64](
-			either.Right[string, int]{3},
-			either.Right[string, float64]{2.0},
+	t.Run("First, First", func(t *testing.T) {
+		res := either.And[int, string, float64](
+			either.First[int, string]{3},
+			either.First[float64, string]{2.0},
 		)
-		expected := either.Right[string, float64]{2.0}
+		expected := either.First[float64, string]{2.0}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Right, Left", func(t *testing.T) {
-		res := either.And[string, int, float64](
-			either.Right[string, int]{3},
-			either.Left[string, float64]{"err"},
+	t.Run("First, Second", func(t *testing.T) {
+		res := either.And[int, string, float64](
+			either.First[int, string]{3},
+			either.Second[float64, string]{"second"},
 		)
-		expected := either.Left[string, float64]{"err"}
+		expected := either.Second[float64, string]{"second"}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left, Right", func(t *testing.T) {
-		res := either.And[string, int, float64](
-			either.Left[string, int]{"err"},
-			either.Right[string, float64]{2.0},
+	t.Run("Second, First", func(t *testing.T) {
+		res := either.And[int, string, float64](
+			either.Second[int, string]{"second"},
+			either.First[float64, string]{2.0},
 		)
-		expected := either.Left[string, float64]{"err"}
+		expected := either.Second[float64, string]{"second"}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left, Left", func(t *testing.T) {
-		res := either.And[string, int, float64](
-			either.Left[string, int]{"some err"},
-			either.Left[string, float64]{"other err"},
+	t.Run("Second, Second", func(t *testing.T) {
+		res := either.And[int, string, float64](
+			either.Second[int, string]{"some second"},
+			either.Second[float64, string]{"other second"},
 		)
-		expected := either.Left[string, float64]{"some err"}
+		expected := either.Second[float64, string]{"some second"}
 		if res != expected {
 			t.Fail()
 		}
@@ -331,44 +331,44 @@ func TestEither_And(t *testing.T) {
 }
 
 func TestEither_AndThen(t *testing.T) {
-	t.Run("Right, f returns Right", func(t *testing.T) {
+	t.Run("First, f returns First", func(t *testing.T) {
 		calls := 0
-		res := either.AndThen[string, int](
-			either.Right[string, int]{3},
-			func(i int) either.Either[string, float64] {
+		res := either.AndThen[int, string](
+			either.First[int, string]{3},
+			func(i int) either.Either[float64, string] {
 				calls++
-				return either.Right[string, float64]{2.0}
+				return either.First[float64, string]{2.0}
 			},
 		)
-		expected := either.Right[string, float64]{2.0}
+		expected := either.First[float64, string]{2.0}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Right, f returns Left", func(t *testing.T) {
+	t.Run("First, f returns Second", func(t *testing.T) {
 		calls := 0
-		res := either.AndThen[string, int](
-			either.Right[string, int]{3},
-			func(i int) either.Either[string, float64] {
+		res := either.AndThen[int, string](
+			either.First[int, string]{3},
+			func(i int) either.Either[float64, string] {
 				calls++
-				return either.Left[string, float64]{"hello"}
+				return either.Second[float64, string]{"hello"}
 			},
 		)
-		expected := either.Left[string, float64]{"hello"}
+		expected := either.Second[float64, string]{"hello"}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Left, f not called", func(t *testing.T) {
+	t.Run("Second, f not called", func(t *testing.T) {
 		calls := 0
-		res := either.AndThen[string, int](
-			either.Left[string, int]{"hello"},
-			func(i int) either.Either[string, float64] {
+		res := either.AndThen[int, string](
+			either.Second[int, string]{"hello"},
+			func(i int) either.Either[float64, string] {
 				calls++
-				return either.Left[string, float64]{"world"}
+				return either.Second[float64, string]{"world"}
 			},
 		)
-		expected := either.Left[string, float64]{"hello"}
+		expected := either.Second[float64, string]{"hello"}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
@@ -376,42 +376,42 @@ func TestEither_AndThen(t *testing.T) {
 }
 
 func TestEither_Or(t *testing.T) {
-	t.Run("Right, Right", func(t *testing.T) {
-		res := either.Or[string, float64, int](
-			either.Right[string, int]{3},
-			either.Right[float64, int]{4},
+	t.Run("First, First", func(t *testing.T) {
+		res := either.Or[int, string, float64](
+			either.First[int, string]{3},
+			either.First[int, float64]{4},
 		)
-		expected := either.Right[float64, int]{3}
+		expected := either.First[int, float64]{3}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Right, Left", func(t *testing.T) {
-		res := either.Or[string, float64, int](
-			either.Right[string, int]{3},
-			either.Left[float64, int]{2.0},
+	t.Run("First, Second", func(t *testing.T) {
+		res := either.Or[int, string, float64](
+			either.First[int, string]{3},
+			either.Second[int, float64]{2.0},
 		)
-		expected := either.Right[float64, int]{3}
+		expected := either.First[int, float64]{3}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left, Right", func(t *testing.T) {
-		res := either.Or[string, float64, int](
-			either.Left[string, int]{"err"},
-			either.Right[float64, int]{2},
+	t.Run("Second, First", func(t *testing.T) {
+		res := either.Or[int, string, float64](
+			either.Second[int, string]{"second"},
+			either.First[int, float64]{2},
 		)
-		expected := either.Right[float64, int]{2}
+		expected := either.First[int, float64]{2}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left, Left", func(t *testing.T) {
-		res := either.Or[string, float64, int](
-			either.Left[string, int]{"some err"},
-			either.Left[float64, int]{1.0},
+	t.Run("Second, Second", func(t *testing.T) {
+		res := either.Or[int, string, float64](
+			either.Second[int, string]{"some second"},
+			either.Second[int, float64]{1.0},
 		)
-		expected := either.Left[float64, int]{1.0}
+		expected := either.Second[int, float64]{1.0}
 		if res != expected {
 			t.Fail()
 		}
@@ -419,44 +419,44 @@ func TestEither_Or(t *testing.T) {
 }
 
 func TestEither_OrElse(t *testing.T) {
-	t.Run("Right, f not called", func(t *testing.T) {
+	t.Run("First, f not called", func(t *testing.T) {
 		calls := 0
-		res := either.OrElse[string, float64, int](
-			either.Right[string, int]{3},
-			func(_ string) either.Either[float64, int] {
+		res := either.OrElse[int, string](
+			either.First[int, string]{3},
+			func(_ string) either.Either[int, float64] {
 				calls++
-				return either.Left[float64, int]{2.0}
+				return either.Second[int, float64]{2.0}
 			},
 		)
-		expected := either.Right[float64, int]{3}
+		expected := either.First[int, float64]{3}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
 	})
-	t.Run("Left, f returns Right", func(t *testing.T) {
+	t.Run("Second, f returns First", func(t *testing.T) {
 		calls := 0
-		res := either.OrElse[string, float64, int](
-			either.Left[string, int]{"hello"},
-			func(s string) either.Either[float64, int] {
+		res := either.OrElse[int, string](
+			either.Second[int, string]{"hello"},
+			func(s string) either.Either[int, float64] {
 				calls++
-				return either.Right[float64, int]{len(s)}
+				return either.First[int, float64]{len(s)}
 			},
 		)
-		expected := either.Right[float64, int]{5}
+		expected := either.First[int, float64]{5}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Left, f returns Left", func(t *testing.T) {
+	t.Run("Second, f returns Second", func(t *testing.T) {
 		calls := 0
-		res := either.OrElse[string, float64, int](
-			either.Left[string, int]{"hello"},
-			func(s string) either.Either[float64, int] {
+		res := either.OrElse[int, string](
+			either.Second[int, string]{"hello"},
+			func(s string) either.Either[int, float64] {
 				calls++
-				return either.Left[float64, int]{float64(len(s))}
+				return either.Second[int, float64]{float64(len(s))}
 			},
 		)
-		expected := either.Left[float64, int]{5}
+		expected := either.Second[int, float64]{5}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
@@ -464,33 +464,33 @@ func TestEither_OrElse(t *testing.T) {
 }
 
 func TestEither_Flatten(t *testing.T) {
-	t.Run("Right[Right]", func(t *testing.T) {
-		res := either.Flatten[string, int](
-			either.Right[string, either.Either[string, int]]{
-				either.Right[string, int]{3},
+	t.Run("First[First]", func(t *testing.T) {
+		res := either.Flatten[int, string](
+			either.First[either.Either[int, string], string]{
+				either.First[int, string]{3},
 			},
 		)
-		expected := either.Right[string, int]{3}
+		expected := either.First[int, string]{3}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Right[Left]", func(t *testing.T) {
-		res := either.Flatten[string, int](
-			either.Right[string, either.Either[string, int]]{
-				either.Left[string, int]{"err"},
+	t.Run("First[Second]", func(t *testing.T) {
+		res := either.Flatten[int, string](
+			either.First[either.Either[int, string], string]{
+				either.Second[int, string]{"second"},
 			},
 		)
-		expected := either.Left[string, int]{"err"}
+		expected := either.Second[int, string]{"second"}
 		if res != expected {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		res := either.Flatten[string, int](
-			either.Left[string, either.Either[string, int]]{"hello"},
+	t.Run("Second", func(t *testing.T) {
+		res := either.Flatten[int, string](
+			either.Second[either.Either[int, string], string]{"hello"},
 		)
-		expected := either.Left[string, int]{"hello"}
+		expected := either.Second[int, string]{"hello"}
 		if res != expected {
 			t.Fail()
 		}
@@ -498,61 +498,61 @@ func TestEither_Flatten(t *testing.T) {
 }
 
 func TestEither_Map(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
-		res := either.Map[string, int](
-			either.Right[string, int]{3},
+		res := either.Map[int, string](
+			either.First[int, string]{3},
 			func(i int) float64 {
 				calls++
 				return float64(i + 1)
 			},
 		)
-		expected := either.Right[string, float64]{4}
+		expected := either.First[float64, string]{4}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		res := either.Map[string, int](
-			either.Left[string, int]{"err"},
+		res := either.Map[int, string](
+			either.Second[int, string]{"second"},
 			func(i int) float64 {
 				calls++
 				return float64(i + 1)
 			},
 		)
-		expected := either.Left[string, float64]{"err"}
+		expected := either.Second[float64, string]{"second"}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_MapLeft(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+func TestEither_MapSecond(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
-		res := either.MapLeft[string, float64, int](
-			either.Right[string, int]{3},
+		res := either.MapSecond[int, string](
+			either.First[int, string]{3},
 			func(i string) float64 {
 				calls++
 				return float64(len(i) + 1)
 			},
 		)
-		expected := either.Right[float64, int]{3}
+		expected := either.First[int, float64]{int(3)}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		res := either.MapLeft[string, float64, int](
-			either.Left[string, int]{"err"},
+		res := either.MapSecond[int, string](
+			either.Second[int, string]{"second"},
 			func(i string) float64 {
 				calls++
 				return float64(len(i) + 1)
 			},
 		)
-		expected := either.Left[float64, int]{4}
+		expected := either.Second[int, float64]{float64(7)}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
@@ -560,32 +560,32 @@ func TestEither_MapLeft(t *testing.T) {
 }
 
 func TestEither_MapOr(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
-		res := either.MapOr[string, int](
-			either.Right[string, int]{3},
+		res := either.MapOr[int, string](
+			either.First[int, string]{3},
 			float64(600),
 			func(i int) float64 {
 				calls++
 				return float64(i + 1)
 			},
 		)
-		expected := either.Right[string, float64]{4}
+		expected := either.First[float64, string]{4}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		res := either.MapOr[string, int](
-			either.Left[string, int]{"err"},
+		res := either.MapOr[int, string](
+			either.Second[int, string]{"second"},
 			float64(600),
 			func(i int) float64 {
 				calls++
 				return float64(i + 1)
 			},
 		)
-		expected := either.Right[string, float64]{600}
+		expected := either.First[float64, string]{600}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
@@ -593,11 +593,11 @@ func TestEither_MapOr(t *testing.T) {
 }
 
 func TestEither_MapOrElse(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
+	t.Run("First", func(t *testing.T) {
 		calls := 0
 		defaultCalls := 0
-		res := either.MapOrElse[string, int](
-			either.Right[string, int]{3},
+		res := either.MapOrElse[int, string](
+			either.First[int, string]{3},
 			func(e string) float64 {
 				defaultCalls++
 				return float64(len(e))
@@ -607,16 +607,16 @@ func TestEither_MapOrElse(t *testing.T) {
 				return float64(i + 1)
 			},
 		)
-		expected := either.Right[string, float64]{4}
+		expected := either.First[float64, string]{4}
 		if res != expected || calls != 1 || defaultCalls != 0 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
+	t.Run("Second", func(t *testing.T) {
 		calls := 0
 		defaultCalls := 0
-		res := either.MapOrElse[string, int](
-			either.Left[string, int]{"hello world"},
+		res := either.MapOrElse[int, string](
+			either.Second[int, string]{"hello world"},
 			func(e string) float64 {
 				defaultCalls++
 				return float64(len(e))
@@ -626,7 +626,7 @@ func TestEither_MapOrElse(t *testing.T) {
 				return float64(i + 1)
 			},
 		)
-		expected := either.Right[string, float64]{11}
+		expected := either.First[float64, string]{11}
 		if res != expected || calls != 0 || defaultCalls != 1 {
 			t.Fail()
 		}
@@ -634,80 +634,80 @@ func TestEither_MapOrElse(t *testing.T) {
 }
 
 func TestEither_Match(t *testing.T) {
-	t.Run("Right", func(t *testing.T) {
-		rightCalls := 0
-		leftCalls := 0
-		res := either.Match[string, int](either.Right[string, int]{3},
-			func(l either.Left[string, int]) float64 {
-				leftCalls++
-				return float64(600)
+	t.Run("First", func(t *testing.T) {
+		firstCalls := 0
+		secondCalls := 0
+		res := either.Match[int, string](either.First[int, string]{3},
+			func(o either.First[int, string]) float64 {
+				firstCalls++
+				return float64(o.Value + 1)
 			},
-			func(r either.Right[string, int]) float64 {
-				rightCalls++
-				return float64(r.Value + 1)
+			func(e either.Second[int, string]) float64 {
+				secondCalls++
+				return float64(600)
 			},
 		)
 		expected := float64(4)
-		if res != expected || rightCalls != 1 || leftCalls != 0 {
+		if res != expected || firstCalls != 1 || secondCalls != 0 {
 			t.Fail()
 		}
 	})
-	t.Run("Left", func(t *testing.T) {
-		rightCalls := 0
-		leftCalls := 0
-		res := either.Match[string, int](either.Left[string, int]{"hello world"},
-			func(l either.Left[string, int]) float64 {
-				leftCalls++
-				return float64(len(l.Value) + 1)
-			},
-			func(r either.Right[string, int]) float64 {
-				rightCalls++
+	t.Run("Second", func(t *testing.T) {
+		firstCalls := 0
+		secondCalls := 0
+		res := either.Match[int, string](either.Second[int, string]{"hello world"},
+			func(o either.First[int, string]) float64 {
+				firstCalls++
 				return float64(600)
+			},
+			func(e either.Second[int, string]) float64 {
+				secondCalls++
+				return float64(len(e.Value) + 1)
 			},
 		)
 		expected := float64(12)
-		if res != expected || rightCalls != 0 || leftCalls != 1 {
+		if res != expected || firstCalls != 0 || secondCalls != 1 {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_RightOr(t *testing.T) {
+func TestEither_FirstOr(t *testing.T) {
 	t.Run("Some", func(t *testing.T) {
-		res := either.RightOr[string, int](option.Some[int]{Value: 3}, "err")
-		expected := either.Right[string, int]{3}
+		res := either.FirstOr[int](option.Some[int]{Value: 3}, "second")
+		expected := either.First[int, string]{3}
 		if res != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Nothing", func(t *testing.T) {
-		res := either.RightOr[string, int](option.Nothing[int]{}, "err")
-		expected := either.Left[string, int]{"err"}
+		res := either.FirstOr[int](option.Nothing[int]{}, "second")
+		expected := either.Second[int, string]{"second"}
 		if res != expected {
 			t.Fail()
 		}
 	})
 }
 
-func TestEither_RightOrElse(t *testing.T) {
+func TestEither_FirstOrElse(t *testing.T) {
 	t.Run("Some", func(t *testing.T) {
 		calls := 0
-		res := either.RightOrElse[string, int](option.Some[int]{Value: 3}, func() string {
+		res := either.FirstOrElse[int](option.Some[int]{Value: 3}, func() string {
 			calls++
 			return "hello"
 		})
-		expected := either.Right[string, int]{3}
+		expected := either.First[int, string]{3}
 		if res != expected || calls != 0 {
 			t.Fail()
 		}
 	})
 	t.Run("Nothing", func(t *testing.T) {
 		calls := 0
-		res := either.RightOrElse[string, int](option.Nothing[int]{}, func() string {
+		res := either.FirstOrElse[int](option.Nothing[int]{}, func() string {
 			calls++
 			return "hello"
 		})
-		expected := either.Left[string, int]{"hello"}
+		expected := either.Second[int, string]{"hello"}
 		if res != expected || calls != 1 {
 			t.Fail()
 		}
@@ -717,7 +717,7 @@ func TestEither_RightOrElse(t *testing.T) {
 func TestEither_From(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		res := either.From(3, nil)
-		expected := either.Right[error, int]{Value: 3}
+		expected := either.First[int, error]{Value: 3}
 		if res != expected {
 			t.Fail()
 		}
@@ -725,7 +725,7 @@ func TestEither_From(t *testing.T) {
 	t.Run("not nil", func(t *testing.T) {
 		err := fmt.Errorf("error")
 		res := either.From(3, err)
-		expected := either.Left[error, int]{Value: err}
+		expected := either.Second[int, error]{Value: err}
 		if res != expected {
 			t.Fail()
 		}

--- a/iterator/iterator_test.go
+++ b/iterator/iterator_test.go
@@ -67,7 +67,7 @@ func TestAdvanceBy(t *testing.T) {
 		t.Fail()
 	}
 	res = iterator.AdvanceBy[int](iter, 3)
-	if res.UnwrapLeft() != uint64(1) {
+	if res.UnwrapSecond() != uint64(1) {
 		t.Fail()
 	}
 }
@@ -240,12 +240,12 @@ func TestTryFold(t *testing.T) {
 		ret := iterator.TryFold[int](iter, 1,
 			func(a int, t int) either.Either[int, int] {
 				if t < 4 {
-					return either.Right[int, int]{Value: a * t}
+					return either.First[int, int]{Value: a * t}
 				}
-				return either.Left[int, int]{Value: a}
+				return either.Second[int, int]{Value: a}
 			},
 		)
-		if ret.UnwrapLeft() != 6 {
+		if ret.UnwrapSecond() != 6 {
 			t.Fail()
 		}
 		if iter.Next().Unwrap() != 5 { // Iterator should be at the next non-failed element.
@@ -258,7 +258,7 @@ func TestTryFold(t *testing.T) {
 		}
 		ret := iterator.TryFold[int](iter, 1,
 			func(a int, t int) either.Either[int, int] {
-				return either.Right[int, int]{Value: a * t}
+				return either.First[int, int]{Value: a * t}
 			},
 		)
 		if ret.Unwrap() != 120 {

--- a/maputil/maputil.go
+++ b/maputil/maputil.go
@@ -87,13 +87,13 @@ func (m Map[K, V]) Len() int {
 // TryInsert tries to insert a key-value pair into the map.
 // If a value V already exists for this key, OccupiedError is returned.
 // Otherwise, the new value is returned.
-func (m Map[K, V]) TryInsert(k K, v V) either.Either[OccupiedError[K, V], V] {
+func (m Map[K, V]) TryInsert(k K, v V) either.Either[V, OccupiedError[K, V]] {
 	val, ok := m.m[k]
 	if !ok {
 		m.m[k] = v
-		return either.Right[OccupiedError[K, V], V]{Value: v}
+		return either.First[V, OccupiedError[K, V]]{Value: v}
 	}
-	return either.Left[OccupiedError[K, V], V]{
+	return either.Second[V, OccupiedError[K, V]]{
 		Value: OccupiedError[K, V]{Key: k, Value: val},
 	}
 }

--- a/maputil/maputil_test.go
+++ b/maputil/maputil_test.go
@@ -123,7 +123,7 @@ func TestTryInsert(t *testing.T) {
 			"key 3": 3,
 		})
 		res := m.TryInsert("key 4", 4)
-		expectedRes := either.Right[maputil.OccupiedError[string, int], int]{Value: 4}
+		expectedRes := either.First[int, maputil.OccupiedError[string, int]]{Value: 4}
 		getVal := m.Get("key 4")
 		expectedGet := option.Some[int]{Value: 4}
 		if res != expectedRes || !m.ContainsKey("key 4") || getVal != expectedGet {
@@ -137,7 +137,7 @@ func TestTryInsert(t *testing.T) {
 			"key 3": 3,
 		})
 		res := m.TryInsert("key 3", 4)
-		expectedRes := either.Left[maputil.OccupiedError[string, int], int]{
+		expectedRes := either.Second[int, maputil.OccupiedError[string, int]]{
 			Value: maputil.OccupiedError[string, int]{
 				Key:   "key 3",
 				Value: 3,


### PR DESCRIPTION
Switches the type arguments back the other way so that the success value reads first and the error value reads second.

Closes #45 