### PR TITLE
Add definition for Result type

### DIFF
--- a/either/either.go
+++ b/either/either.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sidkurella/goption/option"
 )
 
-// Implements Monad[Either[F1, E], Either[F2, E], F1].
+// Implements Monad[Either[F1, S], Either[F2, S], F1].
 type EitherMonad[F1 any, S any, F2 any] struct {
 }
 
@@ -338,7 +338,7 @@ func FirstOrElse[T any, E any](opt option.Option[T], f func() E) Either[T, E] {
 	)
 }
 
-// Returns First[r] if err == nil.
+// Returns First[value] if err == nil.
 // Returns Second[err] if err != nil.
 func From[T any](value T, err error) Either[T, error] {
 	if err != nil {

--- a/iterator/iterator_test.go
+++ b/iterator/iterator_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sidkurella/goption/either"
 	"github.com/sidkurella/goption/iterator"
 	"github.com/sidkurella/goption/option"
 	"github.com/sidkurella/goption/pair"
+	"github.com/sidkurella/goption/result"
 )
 
 type fakeCollection struct {
@@ -75,7 +75,7 @@ func TestAdvanceBy(t *testing.T) {
 		t.Fail()
 	}
 	res = iterator.AdvanceBy[int](iter, 3)
-	if res.UnwrapSecond() != uint64(1) {
+	if res.UnwrapErr() != uint64(1) {
 		t.Fail()
 	}
 }
@@ -268,14 +268,14 @@ func TestTryFold(t *testing.T) {
 			elements: []int{1, 2, 3, 4, 5},
 		}
 		ret := iterator.TryFold[int](iter, 1,
-			func(a int, t int) either.Either[int, int] {
+			func(a int, t int) result.Result[int, int] {
 				if t < 4 {
-					return either.First[int, int](a * t)
+					return result.Ok[int, int](a * t)
 				}
-				return either.Second[int](a)
+				return result.Err[int](a)
 			},
 		)
-		if ret.UnwrapSecond() != 6 {
+		if ret.UnwrapErr() != 6 {
 			t.Fail()
 		}
 		if iter.Next().Unwrap() != 5 { // Iterator should be at the next non-failed element.
@@ -287,8 +287,8 @@ func TestTryFold(t *testing.T) {
 			elements: []int{1, 2, 3, 4, 5},
 		}
 		ret := iterator.TryFold[int](iter, 1,
-			func(a int, t int) either.Either[int, int] {
-				return either.First[int, int](a * t)
+			func(a int, t int) result.Result[int, int] {
+				return result.Ok[int, int](a * t)
 			},
 		)
 		if ret.Unwrap() != 120 {

--- a/maputil/maputil.go
+++ b/maputil/maputil.go
@@ -3,8 +3,8 @@ package maputil
 import (
 	"fmt"
 
-	"github.com/sidkurella/goption/either"
 	"github.com/sidkurella/goption/option"
+	"github.com/sidkurella/goption/result"
 )
 
 // An error indicating that the given key is already in the map, with the given value.
@@ -105,13 +105,13 @@ func (m Map[K, V]) Len() int {
 // TryInsert tries to insert a key-value pair into the map.
 // If a value V already exists for this key, OccupiedError is returned.
 // Otherwise, the new value is returned.
-func (m Map[K, V]) TryInsert(k K, v V) either.Either[V, OccupiedError[K, V]] {
+func (m Map[K, V]) TryInsert(k K, v V) result.Result[V, OccupiedError[K, V]] {
 	val, ok := m.m[k]
 	if !ok {
 		m.m[k] = v
-		return either.First[V, OccupiedError[K, V]](v)
+		return result.Ok[V, OccupiedError[K, V]](v)
 	}
-	return either.Second[V](
+	return result.Err[V](
 		OccupiedError[K, V]{Key: k, Value: val},
 	)
 }

--- a/maputil/maputil_test.go
+++ b/maputil/maputil_test.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sidkurella/goption/either"
 	"github.com/sidkurella/goption/iterator"
 	"github.com/sidkurella/goption/maputil"
 	"github.com/sidkurella/goption/option"
+	"github.com/sidkurella/goption/result"
 	"github.com/sidkurella/goption/sliceutil"
 )
 
@@ -169,7 +169,7 @@ func TestTryInsert(t *testing.T) {
 			"key 3": 3,
 		})
 		res := m.TryInsert("key 4", 4)
-		expectedRes := either.First[int, maputil.OccupiedError[string, int]](4)
+		expectedRes := result.Ok[int, maputil.OccupiedError[string, int]](4)
 		getVal := m.Get("key 4")
 		expectedGet := option.Some(4)
 		if res != expectedRes || !m.ContainsKey("key 4") || getVal != expectedGet {
@@ -183,7 +183,7 @@ func TestTryInsert(t *testing.T) {
 			"key 3": 3,
 		})
 		res := m.TryInsert("key 3", 4)
-		expectedRes := either.Second[int](
+		expectedRes := result.Err[int](
 			maputil.OccupiedError[string, int]{
 				Key:   "key 3",
 				Value: 3,

--- a/result/result.go
+++ b/result/result.go
@@ -1,0 +1,349 @@
+package result
+
+import (
+	"fmt"
+
+	"github.com/sidkurella/goption/option"
+)
+
+// Implements Monad[Result[T, E], Result[U, E], T].
+type ResultMonad[T any, E any, U any] struct {
+}
+
+func (m ResultMonad[T, E, U]) Bind(val Result[T, E], f func(T) Result[U, E]) Result[U, E] {
+	return Match(val,
+		func(ok T) Result[U, E] {
+			return f(ok)
+		},
+		func(err E) Result[U, E] {
+			return Err[U](err)
+		},
+	)
+}
+
+func (m ResultMonad[T1, E, T2]) Return(val T1) Result[T1, E] {
+	return Ok[T1, E](val)
+}
+
+type resultVariant int
+
+const (
+	resultVariantErr resultVariant = iota
+	resultVariantOk
+)
+
+// Result type. Represents either the success variant Ok(T) containing a success value
+// or an Err(E) variant containing an error type. The default value is Err(*new(E))
+// (i.e. Err variant containing the zero value of E).
+type Result[T any, E any] struct {
+	variant resultVariant
+	ok      T
+	err     E
+}
+
+//=====================================================
+
+func Ok[T any, E any](t T) Result[T, E] {
+	return Result[T, E]{
+		variant: resultVariantOk,
+		ok:      t,
+	}
+}
+
+func Err[T any, E any](e E) Result[T, E] {
+	return Result[T, E]{
+		variant: resultVariantErr,
+		err:     e,
+	}
+}
+
+// Returns true if the result is Ok.
+func (e Result[T, E]) IsOk() bool {
+	return e.variant == resultVariantOk
+}
+
+// Returns true if the result is Ok and matches the given predicate.
+func (e Result[T, E]) IsOkAnd(pred func(*T) bool) bool {
+	return e.IsOk() && pred(&e.ok)
+}
+
+// Returns true if the result is Err.
+func (e Result[T, E]) IsErr() bool {
+	return e.variant == resultVariantErr
+}
+
+// Returns true if the result is Err and matches the given predicate.
+func (e Result[T, E]) IsErrAnd(pred func(*E) bool) bool {
+	return e.IsErr() && pred(&e.err)
+}
+
+// Converts from Result[T, E] to Option[T].
+// Converts self into an Option[T], discarding the Err value, if any.
+func (e Result[T, E]) Ok() option.Option[T] {
+	if e.IsOk() {
+		return option.Some(e.ok)
+	}
+	return option.Nothing[T]()
+}
+
+// Converts from Result[T, E] to Option[E].
+// Converts self into an Option[E], and discarding the Ok value, if any.
+func (e Result[T, E]) Err() option.Option[E] {
+	if e.IsErr() {
+		return option.Some(e.err)
+	}
+	return option.Nothing[E]()
+}
+
+// Returns the contained Ok value. Panics with the given message if the result is not Ok.
+func (e Result[T, E]) Expect(msg string) T {
+	return Match(e,
+		func(t T) T {
+			return t
+		},
+		func(_ E) T {
+			panic(msg)
+		},
+	)
+}
+
+// Returns the contained Err value. Panics with the given message if the result is not Err.
+func (e Result[T, E]) ExpectErr(msg string) E {
+	return Match(e,
+		func(_ T) E {
+			panic(msg)
+		},
+		func(e E) E {
+			return e
+		},
+	)
+}
+
+// Unwrap returns the contained Ok value. Panics if it is Err.
+func (e Result[T, E]) Unwrap() T {
+	return e.Expect("result was Err")
+}
+
+// Returns the contained Ok value. If the result is Err, returns the provided default.
+// Default value is eagerly evaluated. Consider using UnwrapOrElse if providing the return value of a function call.
+func (e Result[T, E]) UnwrapOr(defaultValue T) T {
+	return Match(e,
+		func(t T) T {
+			return t
+		},
+		func(_ E) T {
+			return defaultValue
+		},
+	)
+}
+
+// Returns the contained Ok value. If the result is Err, computes the default from the provided closure.
+func (e Result[T, E]) UnwrapOrElse(defaultFunc func(E) T) T {
+	return Match(e,
+		func(t T) T {
+			return t
+		},
+		func(e E) T {
+			return defaultFunc(e)
+		},
+	)
+}
+
+// Returns the contained Err value. Panics if it is Ok.
+func (e Result[T, E]) UnwrapErr() E {
+	return e.ExpectErr("result was Ok")
+}
+
+// Returns the contained Err value. If the result is Ok, returns the provided default.
+func (e Result[T, E]) UnwrapErrOr(defaultValue E) E {
+	return Match(e,
+		func(_ T) E {
+			return defaultValue
+		},
+		func(e E) E {
+			return e
+		},
+	)
+}
+
+// Returns the contained Err value. If the result is Ok, computes the default from the provided closure.
+func (e Result[T, E]) UnwrapErrOrElse(defaultFunc func(T) E) E {
+	return Match(e,
+		func(t T) E {
+			return defaultFunc(t)
+		},
+		func(e E) E {
+			return e
+		},
+	)
+}
+
+// Returns a string representation of this Result.
+func (e Result[T, E]) String() string {
+	return Match(e,
+		func(t T) string {
+			return fmt.Sprintf("Ok(%v)", t)
+		},
+		func(e E) string {
+			return fmt.Sprintf("Err(%v)", e)
+		},
+	)
+}
+
+//=====================================================
+
+// Returns res2 if res1 is Ok, otherwise returns the Err value of res1.
+func And[T any, E any, U any](res1 Result[T, E], res2 Result[U, E]) Result[U, E] {
+	return ResultMonad[T, E, U]{}.Bind(
+		res1,
+		func(_ T) Result[U, E] {
+			return res2
+		},
+	)
+}
+
+// Returns f(T) if res1 is Ok[T], otherwise returns the Err value of res1.
+func AndThen[T any, E any, U any](res1 Result[T, E], f func(T) Result[U, E]) Result[U, E] {
+	return ResultMonad[T, E, U]{}.Bind(res1, f)
+}
+
+// Flattens a result of type Result[Result[T, E], E] to just Result[T, E].
+func Flatten[T any, E any](res Result[Result[T, E], E]) Result[T, E] {
+	return Match(res,
+		func(r Result[T, E]) Result[T, E] {
+			return r
+		},
+		func(e E) Result[T, E] {
+			return Err[T](e)
+		},
+	)
+}
+
+// Maps a Result[T, E] to Result[U, E] by applying a function to a contained Ok value.
+// Leaves an Err value untouched.
+func Map[T any, E any, U any](res Result[T, E], f func(T) U) Result[U, E] {
+	return Match(res,
+		func(ok T) Result[U, E] {
+			return Ok[U, E](f(ok))
+		},
+		func(e E) Result[U, E] {
+			return Err[U](e)
+		},
+	)
+}
+
+// Maps a Result[T, E] to Result[T, E2] by applying a function to a contained Err value.
+// Leaves an Ok value untouched.
+func MapErr[T any, E any, E2 any](res Result[T, E], f func(E) E2) Result[T, E2] {
+	return Match(res,
+		func(ok T) Result[T, E2] {
+			return Ok[T, E2](ok)
+		},
+		func(e E) Result[T, E2] {
+			return Err[T](f(e))
+		},
+	)
+}
+
+// Maps a Result[T, E] to Result[U, E] by applying a function to a contained Ok value.
+// Returns the provided default if it is Err.
+// Default value is eagerly evaluated. Consider using MapOrElse if you are passing the return value of a function call.
+func MapOr[T any, E any, U any](res Result[T, E], defaultValue U, f func(T) U) Result[U, E] {
+	return Match(res,
+		func(ok T) Result[U, E] {
+			return Ok[U, E](f(ok))
+		},
+		func(_ E) Result[U, E] {
+			return Ok[U, E](defaultValue)
+		},
+	)
+}
+
+// Maps a Result[T, E] to Result[U, E] by applying a function to a contained Ok value.
+// Returns the result produced by the default function if it is Err.
+// Default is lazily evaluated.
+func MapOrElse[T any, E any, U any](res Result[T, E], defaultFunc func(E) U, f func(T) U) Result[U, E] {
+	return Match(res,
+		func(ok T) Result[U, E] {
+			return Ok[U, E](f(ok))
+		},
+		func(e E) Result[U, E] {
+			return Ok[U, E](defaultFunc(e))
+		},
+	)
+}
+
+// Returns res2 if the result is Err, otherwise returns the Ok value of res1.
+// res2 is eagerly evaluated. Consider using OrElse if you are passing the result of a function call.
+func Or[T any, E any, E2 any](res1 Result[T, E], res2 Result[T, E2]) Result[T, E2] {
+	return Match(res1,
+		func(t T) Result[T, E2] {
+			return Ok[T, E2](t)
+		},
+		func(e E) Result[T, E2] {
+			return res2
+		},
+	)
+}
+
+// Returns f(T) if the result is Err[T], otherwise returns the Ok value of res1.
+// f is lazily evaluated.
+func OrElse[T any, E any, E2 any](res1 Result[T, E], f func(E) Result[T, E2]) Result[T, E2] {
+	return Match(res1,
+		func(t T) Result[T, E2] {
+			return Ok[T, E2](t)
+		},
+		func(e E) Result[T, E2] {
+			return f(e)
+		},
+	)
+}
+
+// Match calls okArm if the result is Ok[T] and returns that.
+// It calls errArm if the result is Err[E] and returns that instead.
+// The two functions must return the same type.
+func Match[T any, E any, U any](r Result[T, E], okArm func(t T) U, errArm func(e E) U) U {
+	switch r.variant {
+	case resultVariantOk:
+		return okArm(r.ok)
+	case resultVariantErr:
+		return errArm(r.err)
+	default:
+		panic("result type is neither Ok[T, E] nor Err[T, E]") // This should never happen.
+	}
+}
+
+// Converts an Option[T] to a Result[T, E], mapping Some[T] to Ok[T], and Nothing to Err[err].
+// Arguments are eagerly evaluated; consider using OkOrElse if passing the result of a function call.
+func OkOr[T any, E any](opt option.Option[T], err E) Result[T, E] {
+	return option.Match(opt,
+		func(t T) Result[T, E] {
+			return Ok[T, E](t)
+		},
+		func() Result[T, E] {
+			return Err[T](err)
+		},
+	)
+}
+
+// Converts an Option[T] to a Result[T, E], mapping Some[T] to Ok[T], and Nothing to Err[f()].
+// f is lazily evaluated.
+func OkOrElse[T any, E any](opt option.Option[T], f func() E) Result[T, E] {
+	return option.Match(opt,
+		func(t T) Result[T, E] {
+			return Ok[T, E](t)
+		},
+		func() Result[T, E] {
+			return Err[T](f())
+		},
+	)
+}
+
+// Returns Ok[value] if err == nil.
+// Returns Err[err] if err != nil.
+func From[T any](value T, err error) Result[T, error] {
+	if err != nil {
+		return Err[T](err)
+	}
+	return Ok[T, error](value)
+}

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -1,0 +1,733 @@
+package result_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/sidkurella/goption/option"
+	"github.com/sidkurella/goption/result"
+)
+
+func TestResult_IsOk(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		if !val.IsOk() {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("err val")
+		if val.IsOk() {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_IsErr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		if val.IsErr() {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("err val")
+		if !val.IsErr() {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_IsOkAnd(t *testing.T) {
+	t.Run("Ok, passes predicate", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		if !val.IsOkAnd(func(t *int) bool { return (*t) == 3 }) {
+			t.Fail()
+		}
+	})
+	t.Run("Ok, fails predicate", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		if val.IsOkAnd(func(t *int) bool { return (*t) == 4 }) {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("err val")
+		if val.IsOkAnd(func(t *int) bool { return (*t) == 4 }) {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_IsErrAnd(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		if val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+	t.Run("Err, passes predicate", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		if !val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+	t.Run("Err, fails predicate", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("world")
+		if val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Ok(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := option.Some(3)
+		if val.Ok() != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := option.Nothing[int]()
+		if val.Ok() != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Err(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := option.Nothing[string]()
+		if val.Err() != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := option.Some("hello")
+		if val.Err() != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Unwrap(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := 3
+		if val.Unwrap() != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Panic was expected but did not occur")
+			}
+		}()
+
+		var val result.Result[int, string] = result.Err[int]("hello")
+		_ = val.Unwrap()
+	})
+}
+
+func TestResult_UnwrapOr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := 3
+		if val.UnwrapOr(4) != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := 4
+		if val.UnwrapOr(4) != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_UnwrapOrElse(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := 3
+		if val.UnwrapOrElse(func(_ string) int {
+			calls++
+			return 4
+		}) != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := 5
+		if val.UnwrapOrElse(func(s string) int {
+			calls++
+			return len(s)
+		}) != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_UnwrapErr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Panic was expected but did not occur")
+			}
+		}()
+
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		_ = val.UnwrapErr()
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := "hello"
+		if val.UnwrapErr() != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_UnwrapErrOr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := "world"
+		if val.UnwrapErrOr("world") != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := "hello"
+		if val.UnwrapErrOr("world") != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_UnwrapErrOrElse(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := "3"
+		if val.UnwrapErrOrElse(func(i int) string {
+			calls++
+			return strconv.Itoa(i)
+		}) != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := "hello"
+		if val.UnwrapErrOrElse(func(i int) string {
+			calls++
+			return strconv.Itoa(i)
+		}) != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Expect(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		expected := 3
+		if val.Expect("don't panic") != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		msg := "panic expected"
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Errorf("Panic was expected but did not occur")
+			} else if r != msg {
+				t.Errorf("Panic was expected but message was %v (did not match expected msg %v)", r, msg)
+			}
+		}()
+
+		var val result.Result[int, string] = result.Err[int]("hello")
+		_ = val.Expect(msg)
+	})
+}
+
+func TestResult_ExpectErr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		msg := "panic expected"
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Errorf("Panic was expected but did not occur")
+			} else if r != msg {
+				t.Errorf("Panic was expected but message was %v (did not match expected msg %v)", r, msg)
+			}
+		}()
+
+		var val result.Result[int, string] = result.Ok[int, string](3)
+		_ = val.ExpectErr(msg)
+	})
+	t.Run("Err", func(t *testing.T) {
+		var val result.Result[int, string] = result.Err[int]("hello")
+		expected := "hello"
+		if val.ExpectErr("don't panic") != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_And(t *testing.T) {
+	t.Run("Ok, Ok", func(t *testing.T) {
+		res := result.And(
+			result.Ok[int, string](3),
+			result.Ok[float64, string](2.0),
+		)
+		expected := result.Ok[float64, string](2.0)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Ok, Err", func(t *testing.T) {
+		res := result.And(
+			result.Ok[int, string](3),
+			result.Err[float64]("err"),
+		)
+		expected := result.Err[float64]("err")
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err, Ok", func(t *testing.T) {
+		res := result.And(
+			result.Err[int]("err"),
+			result.Ok[float64, string](2.0),
+		)
+		expected := result.Err[float64]("err")
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err, Err", func(t *testing.T) {
+		res := result.And(
+			result.Err[int]("some err"),
+			result.Err[float64]("other err"),
+		)
+		expected := result.Err[float64]("some err")
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_AndThen(t *testing.T) {
+	t.Run("Ok, f returns Ok", func(t *testing.T) {
+		calls := 0
+		res := result.AndThen(
+			result.Ok[int, string](3),
+			func(i int) result.Result[float64, string] {
+				calls++
+				return result.Ok[float64, string](2.0)
+			},
+		)
+		expected := result.Ok[float64, string](2.0)
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Ok, f returns Err", func(t *testing.T) {
+		calls := 0
+		res := result.AndThen(
+			result.Ok[int, string](3),
+			func(i int) result.Result[float64, string] {
+				calls++
+				return result.Err[float64]("hello")
+			},
+		)
+		expected := result.Err[float64]("hello")
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Err, f not called", func(t *testing.T) {
+		calls := 0
+		res := result.AndThen(
+			result.Err[int]("hello"),
+			func(i int) result.Result[float64, string] {
+				calls++
+				return result.Err[float64]("world")
+			},
+		)
+		expected := result.Err[float64]("hello")
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Or(t *testing.T) {
+	t.Run("Ok, Ok", func(t *testing.T) {
+		res := result.Or(
+			result.Ok[int, string](3),
+			result.Ok[int, float64](4),
+		)
+		expected := result.Ok[int, float64](3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Ok, Err", func(t *testing.T) {
+		res := result.Or(
+			result.Ok[int, string](3),
+			result.Err[int](2.0),
+		)
+		expected := result.Ok[int, float64](3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err, Ok", func(t *testing.T) {
+		res := result.Or(
+			result.Err[int]("err"),
+			result.Ok[int, float64](2),
+		)
+		expected := result.Ok[int, float64](2)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err, Err", func(t *testing.T) {
+		res := result.Or(
+			result.Err[int]("some err"),
+			result.Err[int](1.0),
+		)
+		expected := result.Err[int](1.0)
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_OrElse(t *testing.T) {
+	t.Run("Ok, f not called", func(t *testing.T) {
+		calls := 0
+		res := result.OrElse(
+			result.Ok[int, string](3),
+			func(_ string) result.Result[int, float64] {
+				calls++
+				return result.Err[int](2.0)
+			},
+		)
+		expected := result.Ok[int, float64](3)
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Err, f returns Ok", func(t *testing.T) {
+		calls := 0
+		res := result.OrElse(
+			result.Err[int]("hello"),
+			func(s string) result.Result[int, float64] {
+				calls++
+				return result.Ok[int, float64](len(s))
+			},
+		)
+		expected := result.Ok[int, float64](5)
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Err, f returns Err", func(t *testing.T) {
+		calls := 0
+		res := result.OrElse(
+			result.Err[int]("hello"),
+			func(s string) result.Result[int, float64] {
+				calls++
+				return result.Err[int](float64(len(s)))
+			},
+		)
+		expected := result.Err[int, float64](5)
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Flatten(t *testing.T) {
+	t.Run("Ok[Ok]", func(t *testing.T) {
+		res := result.Flatten(
+			result.Ok[result.Result[int, string], string](
+				result.Ok[int, string](3),
+			),
+		)
+		expected := result.Ok[int, string](3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Ok[Err]", func(t *testing.T) {
+		res := result.Flatten(
+			result.Ok[result.Result[int, string], string](
+				result.Err[int]("err"),
+			),
+		)
+		expected := result.Err[int]("err")
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		res := result.Flatten(
+			result.Err[result.Result[int, string]]("hello"),
+		)
+		expected := result.Err[int]("hello")
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Map(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		res := result.Map(
+			result.Ok[int, string](3),
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Ok[float64, string](4)
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		res := result.Map(
+			result.Err[int]("err"),
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Err[float64]("err")
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_MapErr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		res := result.MapErr(
+			result.Ok[int, string](3),
+			func(i string) float64 {
+				calls++
+				return float64(len(i) + 1)
+			},
+		)
+		expected := result.Ok[int, float64](int(3))
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		res := result.MapErr(
+			result.Err[int]("err"),
+			func(i string) float64 {
+				calls++
+				return float64(len(i) + 1)
+			},
+		)
+		expected := result.Err[int](float64(4))
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_MapOr(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		res := result.MapOr(
+			result.Ok[int, string](3),
+			float64(600),
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Ok[float64, string](4)
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		res := result.MapOr(
+			result.Err[int]("err"),
+			float64(600),
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Ok[float64, string](600)
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_MapOrElse(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		calls := 0
+		defaultCalls := 0
+		res := result.MapOrElse(
+			result.Ok[int, string](3),
+			func(e string) float64 {
+				defaultCalls++
+				return float64(len(e))
+			},
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Ok[float64, string](4)
+		if res != expected || calls != 1 || defaultCalls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		calls := 0
+		defaultCalls := 0
+		res := result.MapOrElse(
+			result.Err[int]("hello world"),
+			func(e string) float64 {
+				defaultCalls++
+				return float64(len(e))
+			},
+			func(i int) float64 {
+				calls++
+				return float64(i + 1)
+			},
+		)
+		expected := result.Ok[float64, string](11)
+		if res != expected || calls != 0 || defaultCalls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_Match(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		okCalls := 0
+		errCalls := 0
+		res := result.Match(result.Ok[int, string](3),
+			func(f int) float64 {
+				okCalls++
+				return float64(f + 1)
+			},
+			func(s string) float64 {
+				errCalls++
+				return float64(600)
+			},
+		)
+		expected := float64(4)
+		if res != expected || okCalls != 1 || errCalls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Err", func(t *testing.T) {
+		okCalls := 0
+		errCalls := 0
+		res := result.Match(result.Err[int]("hello world"),
+			func(f int) float64 {
+				okCalls++
+				return float64(600)
+			},
+			func(s string) float64 {
+				errCalls++
+				return float64(len(s) + 1)
+			},
+		)
+		expected := float64(12)
+		if res != expected || okCalls != 0 || errCalls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_OkOr(t *testing.T) {
+	t.Run("Some", func(t *testing.T) {
+		res := result.OkOr(option.Some(3), "err")
+		expected := result.Ok[int, string](3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Nothing", func(t *testing.T) {
+		res := result.OkOr(option.Nothing[int](), "err")
+		expected := result.Err[int]("err")
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_OkOrElse(t *testing.T) {
+	t.Run("Some", func(t *testing.T) {
+		calls := 0
+		res := result.OkOrElse(option.Some(3), func() string {
+			calls++
+			return "hello"
+		})
+		expected := result.Ok[int, string](3)
+		if res != expected || calls != 0 {
+			t.Fail()
+		}
+	})
+	t.Run("Nothing", func(t *testing.T) {
+		calls := 0
+		res := result.OkOrElse(option.Nothing[int](), func() string {
+			calls++
+			return "hello"
+		})
+		expected := result.Err[int]("hello")
+		if res != expected || calls != 1 {
+			t.Fail()
+		}
+	})
+}
+
+func TestResult_From(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		res := result.From(3, nil)
+		expected := result.Ok[int, error](3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("not nil", func(t *testing.T) {
+		err := fmt.Errorf("error")
+		res := result.From(3, err)
+		expected := result.Err[int](err)
+		if res != expected {
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
Add this back as it is useful to have a specialized type that clearly indicates that one path is success and one is failure.