### PR TITLE
Add Option.FromPointer helper (#73)

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -259,6 +259,15 @@ func From[T any](val T, ok bool) Option[T] {
 	return Nothing[T]()
 }
 
+// Returns an option from the provided pointer.
+// Returns Nothing if p is nil.
+func FromPointer[T any](p *T) Option[T] {
+	if p == nil {
+		return Nothing[T]()
+	}
+	return Some(*p)
+}
+
 // Returns an option from the provided value and error.
 // Returns Some[T] if the error is nil.
 // Returns Nothing if the error is not nil.

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -491,6 +491,24 @@ func TestOption_From(t *testing.T) {
 	})
 }
 
+func TestOption_FromPointer(t *testing.T) {
+	t.Run("non-nil", func(t *testing.T) {
+		val := 3
+		res := option.FromPointer(&val)
+		expected := option.Some(3)
+		if res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("nil", func(t *testing.T) {
+		res := option.FromPointer[int](nil)
+		expected := option.Nothing[int]()
+		if res != expected {
+			t.Fail()
+		}
+	})
+}
+
 func TestOption_FromError(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		res := option.FromError(3, nil)


### PR DESCRIPTION
## Summary
- add `option.FromPointer` to convert `*T` into `Option[T]`
- return `Nothing` for `nil` pointers and `Some(*p)` for non-nil pointers
- add focused tests for nil and non-nil pointer inputs

## Testing
- `go test ./...`

Closes #73