### PR TITLE
Add set Equal and PairedDifference methods (#74)

### DIFF
--- a/set/set.go
+++ b/set/set.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sidkurella/goption/iterator"
 	"github.com/sidkurella/goption/maputil"
 	"github.com/sidkurella/goption/option"
+	"github.com/sidkurella/goption/pair"
 	"github.com/sidkurella/goption/sliceutil"
 )
 
@@ -143,6 +144,17 @@ func (s Set[K]) SymmetricDifference(s2 Set[K]) Set[K] {
 		}
 	})
 	return ret
+}
+
+// Equal returns true if the sets contain exactly the same elements.
+func (s Set[K]) Equal(s2 Set[K]) bool {
+	return s.Len() == s2.Len() && s.IsSubset(s2)
+}
+
+// PairedDifference returns the asymmetric differences partitioned by source set.
+// First contains elements in s but not s2. Second contains elements in s2 but not s.
+func (s Set[K]) PairedDifference(s2 Set[K]) pair.Pair[Set[K], Set[K]] {
+	return pair.From(s.Difference(s2), s2.Difference(s))
 }
 
 // IsDisjoint returns if the two sets have no common elements; that is, their intersection is empty.

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sidkurella/goption/iterator"
 	"github.com/sidkurella/goption/option"
+	"github.com/sidkurella/goption/pair"
 	"github.com/sidkurella/goption/set"
 	"github.com/sidkurella/goption/sliceutil"
 )
@@ -261,6 +262,112 @@ func TestSymmetricDifference(t *testing.T) {
 	if !reflect.DeepEqual(s.SymmetricDifference(s2), expected) {
 		t.Fail()
 	}
+}
+
+func TestEqual(t *testing.T) {
+	t.Run("equal", func(t *testing.T) {
+		s := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+			3: {},
+		})
+		s2 := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+			3: {},
+		})
+		if !s.Equal(s2) {
+			t.Fail()
+		}
+	})
+	t.Run("not equal", func(t *testing.T) {
+		s := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+			3: {},
+		})
+		s2 := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+			4: {},
+		})
+		if s.Equal(s2) {
+			t.Fail()
+		}
+	})
+	t.Run("both empty", func(t *testing.T) {
+		s := set.New[int]()
+		s2 := set.New[int]()
+		if !s.Equal(s2) {
+			t.Fail()
+		}
+	})
+}
+
+func TestPairedDifference(t *testing.T) {
+	t.Run("overlapping sets", func(t *testing.T) {
+		s := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+			3: {},
+		})
+		s2 := set.From(map[int]struct{}{
+			2: {},
+			3: {},
+			4: {},
+		})
+		out := s.PairedDifference(s2)
+		expected := pair.From(
+			set.From(map[int]struct{}{
+				1: {},
+			}),
+			set.From(map[int]struct{}{
+				4: {},
+			}),
+		)
+		if !reflect.DeepEqual(out, expected) {
+			t.Fail()
+		}
+	})
+	t.Run("disjoint sets", func(t *testing.T) {
+		s := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+		})
+		s2 := set.From(map[int]struct{}{
+			3: {},
+			4: {},
+		})
+		out := s.PairedDifference(s2)
+		expected := pair.From(
+			set.From(map[int]struct{}{
+				1: {},
+				2: {},
+			}),
+			set.From(map[int]struct{}{
+				3: {},
+				4: {},
+			}),
+		)
+		if !reflect.DeepEqual(out, expected) {
+			t.Fail()
+		}
+	})
+	t.Run("equal sets", func(t *testing.T) {
+		s := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+		})
+		s2 := set.From(map[int]struct{}{
+			1: {},
+			2: {},
+		})
+		out := s.PairedDifference(s2)
+		expected := pair.From(set.New[int](), set.New[int]())
+		if !reflect.DeepEqual(out, expected) {
+			t.Fail()
+		}
+	})
 }
 
 func TestIsDisjoint(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `Set.Equal` to compare two sets for exact element equality
- add `Set.PairedDifference` to return both asymmetric differences as a `pair.Pair[Set[K], Set[K]]`
- add coverage for equal, non-equal, overlapping, disjoint, and equal-set paired-difference cases

## Testing
- `go test ./...`

Closes #74