### PR TITLE
Harden CI with lint and race checks (#85)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,24 +2,37 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
-
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: "1.23"
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24.x"
 
-    - name: Build
-      run: go build -v ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.1
+          args: ./...
 
-    - name: Test
-      run: go test -v ./...
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24.x"
+          cache: true
+
+      - name: Test
+        run: go test -race ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - errorlint
+    - govet
+    - ineffassign
+    - nolintlint
+    - staticcheck
+    - unconvert
+    - unused
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/README.md
+++ b/README.md
@@ -192,8 +192,20 @@ func main() {
 
 ## Development
 
+Run lint:
+
+```bash
+golangci-lint run ./...
+```
+
 Run all tests:
 
 ```bash
 go test ./...
+```
+
+Run race tests:
+
+```bash
+go test -race ./...
 ```

--- a/either/either_test.go
+++ b/either/either_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestEither_IsFirst(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		if !val.IsFirst() {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("second val")
+		val := either.Second[int]("second val")
 		if val.IsFirst() {
 			t.Fail()
 		}
@@ -26,13 +26,13 @@ func TestEither_IsFirst(t *testing.T) {
 
 func TestEither_IsSecond(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		if val.IsSecond() {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("second val")
+		val := either.Second[int]("second val")
 		if !val.IsSecond() {
 			t.Fail()
 		}
@@ -41,19 +41,19 @@ func TestEither_IsSecond(t *testing.T) {
 
 func TestEither_IsFirstAnd(t *testing.T) {
 	t.Run("First, passes predicate", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		if !val.IsFirstAnd(func(t *int) bool { return (*t) == 3 }) {
 			t.Fail()
 		}
 	})
 	t.Run("First, fails predicate", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		if val.IsFirstAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("second val")
+		val := either.Second[int]("second val")
 		if val.IsFirstAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
@@ -62,19 +62,19 @@ func TestEither_IsFirstAnd(t *testing.T) {
 
 func TestEither_IsSecondAnd(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		if val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
 	})
 	t.Run("Second, passes predicate", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		if !val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
 	})
 	t.Run("Second, fails predicate", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("world")
+		val := either.Second[int]("world")
 		if val.IsSecondAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
@@ -83,14 +83,14 @@ func TestEither_IsSecondAnd(t *testing.T) {
 
 func TestEither_First(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := option.Some(3)
 		if val.First() != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := option.Nothing[int]()
 		if val.First() != expected {
 			t.Fail()
@@ -100,14 +100,14 @@ func TestEither_First(t *testing.T) {
 
 func TestEither_Second(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := option.Nothing[string]()
 		if val.Second() != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := option.Some("hello")
 		if val.Second() != expected {
 			t.Fail()
@@ -117,7 +117,7 @@ func TestEither_Second(t *testing.T) {
 
 func TestEither_Unwrap(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := 3
 		if val.Unwrap() != expected {
 			t.Fail()
@@ -130,21 +130,21 @@ func TestEither_Unwrap(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		_ = val.Unwrap()
 	})
 }
 
 func TestEither_UnwrapOr(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := 3
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := 4
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
@@ -155,7 +155,7 @@ func TestEither_UnwrapOr(t *testing.T) {
 func TestEither_UnwrapOrElse(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
 		calls := 0
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := 3
 		if val.UnwrapOrElse(func(_ string) int {
 			calls++
@@ -166,7 +166,7 @@ func TestEither_UnwrapOrElse(t *testing.T) {
 	})
 	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := 5
 		if val.UnwrapOrElse(func(s string) int {
 			calls++
@@ -185,11 +185,11 @@ func TestEither_UnwrapSecond(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		_ = val.UnwrapSecond()
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := "hello"
 		if val.UnwrapSecond() != expected {
 			t.Fail()
@@ -199,14 +199,14 @@ func TestEither_UnwrapSecond(t *testing.T) {
 
 func TestEither_UnwrapSecondOr(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := "world"
 		if val.UnwrapSecondOr("world") != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := "hello"
 		if val.UnwrapSecondOr("world") != expected {
 			t.Fail()
@@ -217,7 +217,7 @@ func TestEither_UnwrapSecondOr(t *testing.T) {
 func TestEither_UnwrapSecondOrElse(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
 		calls := 0
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := "3"
 		if val.UnwrapSecondOrElse(func(i int) string {
 			calls++
@@ -228,7 +228,7 @@ func TestEither_UnwrapSecondOrElse(t *testing.T) {
 	})
 	t.Run("Second", func(t *testing.T) {
 		calls := 0
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := "hello"
 		if val.UnwrapSecondOrElse(func(i int) string {
 			calls++
@@ -241,7 +241,7 @@ func TestEither_UnwrapSecondOrElse(t *testing.T) {
 
 func TestEither_Expect(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		expected := 3
 		if val.Expect("don't panic") != expected {
 			t.Fail()
@@ -258,7 +258,7 @@ func TestEither_Expect(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		_ = val.Expect(msg)
 	})
 }
@@ -275,11 +275,11 @@ func TestEither_ExpectSecond(t *testing.T) {
 			}
 		}()
 
-		var val either.Either[int, string] = either.First[int, string](3)
+		val := either.First[int, string](3)
 		_ = val.ExpectSecond(msg)
 	})
 	t.Run("Second", func(t *testing.T) {
-		var val either.Either[int, string] = either.Second[int]("hello")
+		val := either.Second[int]("hello")
 		expected := "hello"
 		if val.ExpectSecond("don't panic") != expected {
 			t.Fail()

--- a/iterator/range.go
+++ b/iterator/range.go
@@ -19,7 +19,7 @@ type rangeIterator[T numeric] struct {
 }
 
 func (r *rangeIterator[T]) Next() option.Option[T] {
-	var ret option.Option[T] = option.Nothing[T]()
+	ret := option.Nothing[T]()
 	if (!r.backwards && r.current < r.end) ||
 		(r.backwards && r.current > r.end) ||
 		(r.current == r.end && r.includeEnd) {

--- a/iterator/seq_test.go
+++ b/iterator/seq_test.go
@@ -170,7 +170,7 @@ func TestToSeq2(t *testing.T) {
 		}
 		seq := iterator.ToSeq2(it)
 		var keys []int
-		for k, _ := range seq {
+		for k := range seq {
 			keys = append(keys, k)
 			if k == 2 {
 				break

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestOption_IsSome(t *testing.T) {
 	t.Run("true for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if !opt.IsSome() {
 			t.Fail()
 		}
 	})
 	t.Run("false for Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		if opt.IsSome() {
 			t.Fail()
 		}
@@ -25,13 +25,13 @@ func TestOption_IsSome(t *testing.T) {
 
 func TestOption_IsNothing(t *testing.T) {
 	t.Run("false for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.IsNothing() {
 			t.Fail()
 		}
 	})
 	t.Run("true for Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		if !opt.IsNothing() {
 			t.Fail()
 		}
@@ -40,7 +40,7 @@ func TestOption_IsNothing(t *testing.T) {
 
 func TestOption_Unwrap(t *testing.T) {
 	t.Run("unwrap successful for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.Unwrap() != 4 {
 			t.Fail()
 		}
@@ -52,20 +52,20 @@ func TestOption_Unwrap(t *testing.T) {
 			}
 		}()
 
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		_ = opt.Unwrap()
 	})
 }
 
 func TestOption_UnwrapOr(t *testing.T) {
 	t.Run("returns internal value for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.UnwrapOr(3) != 4 {
 			t.Fail()
 		}
 	})
 	t.Run("returns default for Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		if opt.UnwrapOr(3) != 3 {
 			t.Fail()
 		}
@@ -74,14 +74,14 @@ func TestOption_UnwrapOr(t *testing.T) {
 
 func TestOption_Get(t *testing.T) {
 	t.Run("get succeeds for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		val, ok := opt.Get()
 		if !ok || val != 4 {
 			t.Fail()
 		}
 	})
 	t.Run("returns default for Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		val, ok := opt.Get()
 		if ok || val != 0 {
 			t.Fail()
@@ -91,7 +91,7 @@ func TestOption_Get(t *testing.T) {
 
 func TestOption_Expect(t *testing.T) {
 	t.Run("successful for Some", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.Expect("don't panic") != 4 {
 			t.Fail()
 		}
@@ -107,26 +107,26 @@ func TestOption_Expect(t *testing.T) {
 			}
 		}()
 
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		_ = opt.Expect(msg)
 	})
 }
 
 func TestOption_IsSomeAnd(t *testing.T) {
 	t.Run("successful", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if !opt.IsSomeAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
 	})
 	t.Run("failed", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.IsSomeAnd(func(t *int) bool { return (*t) == 3 }) {
 			t.Fail()
 		}
 	})
 	t.Run("fails for Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		if opt.IsSomeAnd(func(t *int) bool { return (*t) == 3 }) {
 			t.Fail()
 		}
@@ -135,20 +135,20 @@ func TestOption_IsSomeAnd(t *testing.T) {
 
 func TestOption_Filter(t *testing.T) {
 	t.Run("filter passes", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
+		opt := option.Some(4)
 		if opt.Filter(func(t *int) bool { return (*t) == 4 }) != opt {
 			t.Fail()
 		}
 	})
 	t.Run("filter fails", func(t *testing.T) {
-		var opt option.Option[int] = option.Some(4)
-		var target option.Option[int] = option.Nothing[int]()
+		opt := option.Some(4)
+		target := option.Nothing[int]()
 		if opt.Filter(func(t *int) bool { return (*t) == 3 }) != target {
 			t.Fail()
 		}
 	})
 	t.Run("Nothing returns Nothing", func(t *testing.T) {
-		var opt option.Option[int] = option.Nothing[int]()
+		opt := option.Nothing[int]()
 		if opt.Filter(func(t *int) bool { return (*t) == 3 }) != opt {
 			t.Fail()
 		}

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestResult_IsOk(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		if !val.IsOk() {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("err val")
+		val := result.Err[int]("err val")
 		if val.IsOk() {
 			t.Fail()
 		}
@@ -26,13 +26,13 @@ func TestResult_IsOk(t *testing.T) {
 
 func TestResult_IsErr(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		if val.IsErr() {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("err val")
+		val := result.Err[int]("err val")
 		if !val.IsErr() {
 			t.Fail()
 		}
@@ -41,19 +41,19 @@ func TestResult_IsErr(t *testing.T) {
 
 func TestResult_IsOkAnd(t *testing.T) {
 	t.Run("Ok, passes predicate", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		if !val.IsOkAnd(func(t *int) bool { return (*t) == 3 }) {
 			t.Fail()
 		}
 	})
 	t.Run("Ok, fails predicate", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		if val.IsOkAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("err val")
+		val := result.Err[int]("err val")
 		if val.IsOkAnd(func(t *int) bool { return (*t) == 4 }) {
 			t.Fail()
 		}
@@ -62,19 +62,19 @@ func TestResult_IsOkAnd(t *testing.T) {
 
 func TestResult_IsErrAnd(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		if val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
 	})
 	t.Run("Err, passes predicate", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		if !val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
 	})
 	t.Run("Err, fails predicate", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("world")
+		val := result.Err[int]("world")
 		if val.IsErrAnd(func(t *string) bool { return (*t) == "hello" }) {
 			t.Fail()
 		}
@@ -83,14 +83,14 @@ func TestResult_IsErrAnd(t *testing.T) {
 
 func TestResult_Ok(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := option.Some(3)
 		if val.Ok() != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := option.Nothing[int]()
 		if val.Ok() != expected {
 			t.Fail()
@@ -100,14 +100,14 @@ func TestResult_Ok(t *testing.T) {
 
 func TestResult_Err(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := option.Nothing[string]()
 		if val.Err() != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := option.Some("hello")
 		if val.Err() != expected {
 			t.Fail()
@@ -117,7 +117,7 @@ func TestResult_Err(t *testing.T) {
 
 func TestResult_Unwrap(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := 3
 		if val.Unwrap() != expected {
 			t.Fail()
@@ -130,21 +130,21 @@ func TestResult_Unwrap(t *testing.T) {
 			}
 		}()
 
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		_ = val.Unwrap()
 	})
 }
 
 func TestResult_UnwrapOr(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := 3
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := 4
 		if val.UnwrapOr(4) != expected {
 			t.Fail()
@@ -155,7 +155,7 @@ func TestResult_UnwrapOr(t *testing.T) {
 func TestResult_UnwrapOrElse(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
 		calls := 0
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := 3
 		if val.UnwrapOrElse(func(_ string) int {
 			calls++
@@ -166,7 +166,7 @@ func TestResult_UnwrapOrElse(t *testing.T) {
 	})
 	t.Run("Err", func(t *testing.T) {
 		calls := 0
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := 5
 		if val.UnwrapOrElse(func(s string) int {
 			calls++
@@ -185,11 +185,11 @@ func TestResult_UnwrapErr(t *testing.T) {
 			}
 		}()
 
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		_ = val.UnwrapErr()
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := "hello"
 		if val.UnwrapErr() != expected {
 			t.Fail()
@@ -199,14 +199,14 @@ func TestResult_UnwrapErr(t *testing.T) {
 
 func TestResult_UnwrapErrOr(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := "world"
 		if val.UnwrapErrOr("world") != expected {
 			t.Fail()
 		}
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := "hello"
 		if val.UnwrapErrOr("world") != expected {
 			t.Fail()
@@ -217,7 +217,7 @@ func TestResult_UnwrapErrOr(t *testing.T) {
 func TestResult_UnwrapErrOrElse(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
 		calls := 0
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := "3"
 		if val.UnwrapErrOrElse(func(i int) string {
 			calls++
@@ -228,7 +228,7 @@ func TestResult_UnwrapErrOrElse(t *testing.T) {
 	})
 	t.Run("Err", func(t *testing.T) {
 		calls := 0
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := "hello"
 		if val.UnwrapErrOrElse(func(i int) string {
 			calls++
@@ -241,7 +241,7 @@ func TestResult_UnwrapErrOrElse(t *testing.T) {
 
 func TestResult_Expect(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		expected := 3
 		if val.Expect("don't panic") != expected {
 			t.Fail()
@@ -258,7 +258,7 @@ func TestResult_Expect(t *testing.T) {
 			}
 		}()
 
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		_ = val.Expect(msg)
 	})
 }
@@ -275,11 +275,11 @@ func TestResult_ExpectErr(t *testing.T) {
 			}
 		}()
 
-		var val result.Result[int, string] = result.Ok[int, string](3)
+		val := result.Ok[int, string](3)
 		_ = val.ExpectErr(msg)
 	})
 	t.Run("Err", func(t *testing.T) {
-		var val result.Result[int, string] = result.Err[int]("hello")
+		val := result.Err[int]("hello")
 		expected := "hello"
 		if val.ExpectErr("don't panic") != expected {
 			t.Fail()


### PR DESCRIPTION
## Summary
- add a repository lint configuration in `.golangci.yml` and enable `errcheck`, `errorlint`, `govet`, `ineffassign`, `nolintlint`, `staticcheck`, `unconvert`, and `unused`
- modernize GitHub Actions workflow to use pinned current actions (`actions/checkout@v6`, `actions/setup-go@v6`, `golangci/golangci-lint-action@v9`)
- enforce lint and test checks in CI using Go 1.24 and run tests with race detection (`go test -race ./...`)
- update README development section with local lint and race commands
- apply minimal code cleanup required by new lint checks (`:=` inference and range variable formatting)

## Testing
- `golangci-lint run ./...`
- `go test ./...`
- `go test -race ./...`

Closes #85