### PR TITLE
Add Option.ToPointer helper

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -101,6 +101,14 @@ func (o Option[T]) Get() (T, bool) {
 	return o.value, o.IsSome()
 }
 
+// Returns a pointer to the value contained by the option. Returns nil if it is Nothing.
+func (o Option[T]) ToPointer() *T {
+	if o.IsSome() {
+		return &o.value // Since the option is passed by value, there's no mutability concern here.
+	}
+	return nil
+}
+
 // Returns if the option contains a value and the value matches the given predicate.
 func (o Option[T]) IsSomeAnd(pred func(*T) bool) bool {
 	return o.IsSome() && pred(&o.value)

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -525,3 +525,33 @@ func TestOption_FromError(t *testing.T) {
 		}
 	})
 }
+
+func TestOption_ToPointer(t *testing.T) {
+	t.Run("Some", func(t *testing.T) {
+		opt := option.Some(3)
+		res := opt.ToPointer()
+		expected := 3
+		if res == nil || *res != expected {
+			t.Fail()
+		}
+	})
+	t.Run("Nothing", func(t *testing.T) {
+		opt := option.Nothing[int]()
+		res := opt.ToPointer()
+		if res != nil {
+			t.Fail()
+		}
+	})
+	t.Run("modifying pointer does not modify option", func(t *testing.T) {
+		opt := option.Some(3)
+		res := opt.ToPointer()
+		if res == nil {
+			t.Fatalf("Expected non-nil pointer")
+		}
+		*res = 4
+		expectedOpt := option.Some(3)
+		if opt != expectedOpt {
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add `Option.ToPointer()` to return a pointer for `Some` values and `nil` for `Nothing`
- include tests for `Some` and `Nothing` behavior
- verify returned pointer does not alias/mutate the original option value